### PR TITLE
Bug fixes, improved config, new messages, parameter changes, architecture cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ The `ublox_gps` node supports the following parameters for all products and firm
 * `nav_rate` should be set to 1 Hz.
 
 ### For HPG Reference devices:
-* `tmode3`: Time Mode, defaults to Survey-In. See CfgTMODE3 for constants.
-* `arp/lla_flag`: True if the Fixed position is in Lat, Lon, Alt coordinates. False if ECEF. Must be set if `tmode3` is set to fixed. 
-* `arp/position`: Antenna Reference Point position. Must be set if `tmode3` is set to fixed. 
-* `arp/position_hp`: Antenna Reference Point High Precision position. Must be set if tmode3 is set to fixed. 
-* `arp/acc`: Fixed position accuracy. Must be set if `tmode3` is set to fixed. 
+* `tmode3`: Time Mode. Required. See CfgTMODE3 for constants.
+* `arp/lla_flag`: True if the Fixed position is in Lat, Lon, Alt coordinates. False if ECEF. Required if `tmode3` is set to fixed. 
+* `arp/position`: Antenna Reference Point position in [m] or [deg]. Required if `tmode3` is set to fixed. 
+* `arp/position_hp`: Antenna Reference Point High Precision position in [0.1 mm] or [deg * 1e-9]. Required if tmode3 is set to fixed. 
+* `arp/acc`: Fixed position accuracy in [m]. Required if `tmode3` is set to fixed. 
 * `sv_in/reset`: Whether or not to reset the survey in upon initialization. If false, it will only reset if the TMODE is disabled. Defaults to true.
-* `sv_in/min_dur`: The minimum Survey-In Duration time in seconds. Must be set if tmode3 is set to survey in.
-* `sv_in/acc_lim`: The minimum accuracy level of the survey in position in meters. MMust be set if `tmode3` is set to survey in.
+* `sv_in/min_dur`: The minimum Survey-In Duration time in seconds. Required tmode3 is set to survey in.
+* `sv_in/acc_lim`: The minimum accuracy level of the survey in position in meters. Required `tmode3` is set to survey in.
 
 ### For HPG Rover devices:
 * `dgnss_mode`: The Differential GNSS mode. Defaults to RTK FIXED. See `CfgDGNSS` message for constants.
@@ -308,7 +308,8 @@ Currently there are implementations of `ComponentInterface` for firmware version
 
 ## Adding new parameters
 1. Modify the `getRosParams()` method in the appropriate implementation of UbloxComponent (e.g. UbloxNode, UbloxFirmware8, UbloxHpgRef, etc.) and get the parameter. Group multiple related parameters into a namespace. Use all lower case names for parameters and namespaces separated with underscores. 
-* If the type is an unsigned integer (of any size), use the `ublox_node::getRosParam` method which will verify the bounds of the parameter.
+* If the type is an unsigned integer (of any size) or vector of unsigned integers, use the `ublox_node::getRosUint` method which will verify the bounds of the parameter.
+* If the type is an int8 or int16 or vector of int8's or int16s, use the `ublox_nod::getRosInt` method which will verify the bounds of the parameter. (This method can also be used for int32's but ROS has methods to get int32 params as well).
 2. If the parameter is used during configuration also modify the `UbloxComponent`'s `configureUblox()` method to send the appropriate configuration message. Do not send configuration messages in `getRosParams()`.
 3. Modify this README file and add the parameter name and description in the appropriate section. State whether there is a default value or if the parameter is required.
 4. Modify one of the sample `.yaml` configuration files in `ublox_gps/config` to include the parameter or add a new sample `.yaml` for your device.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ The two topics to which you should subscribe are `~fix` and `~fix_velocity`. The
   - Added `UBX-UPD` messages. For firmware version 8, the node can now save the flash memory on shutdown and clear the flash memory during configuration based on ROS params.
   - Added `CfgGPS` message and `MonHW6` message for firmware version 6.
   - Added respawn parameters to example launch file.
+  - Added parameters to load/save configuration.
+  - Added raw_data parameter for Raw Data Products.
   - Changed name of "subscribe" parameter namespace to "publish" for clarity.
   - Migrated all callback handling to `callback.h` from `gps.h` and `gps.cpp`. ACK messages are now processed through callback handlers.
   - Modified how the I/O stream is initialized so that the node now handles parsing the port string.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Example .yaml configuration files are included in `ublox_gps/config`. Consult th
 
 The `ublox_gps` node supports the following parameters for all products and firmware versions:
 * `device`: Path to the device port. Defaults to `/dev/ttyACM0`.
+* `raw_data`: Whether it is a raw data product. Defaults to false. Firmware <= 7.03 only.
 * `uart1/baudrate`: Bit rate of the serial communication. Defaults to 9600.
 * `uart1/in`: UART1 in communication protocol. Defaults to UBX, NMEA & RTCM. See `CfgPRT` message for possible values.
 * `uart1/out`: UART1 out communication protocol. Defaults to UBX, NMEA & RTCM. See `CfgPRT` message for possible values.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The two topics to which you should subscribe are `~fix` and `~fix_velocity`. The
   - Added `UBX-UPD` messages. For firmware version 8, the node can now save the flash memory on shutdown and clear the flash memory during configuration based on ROS params.
   - Added `CfgGPS` message.
   - Added respawn parameters to example launch file.
+  - Changed name of "subscribe" parameter namespace to "publish" for clarity.
   - Migrated all callback handling to `callback.h` from `gps.h` and `gps.cpp`. ACK messages are now processed through callback handlers.
   - Modified how the I/O stream is initialized so that the node now handles parsing the port string.
   - Cleaned up ublox custom serialization classes by adding typedefs and using count to determine repeating block statements instead of using try-catch statements to serialize stream.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ The two topics to which you should subscribe are `~fix` and `~fix_velocity`. The
   - BUG FIX for NavSatFix messages for firmware >=7. The NavSatFix now only uses the NavPVT message time if it is valid, otherwise it uses ROS time.
   - Added `UBX-UPD` messages. For firmware version 8, the node can now save the flash memory on shutdown and clear the flash memory during configuration based on ROS params.
   - Added respawn parameters to example launch file.
+  - Migrated all callback handling to `callback.h` from `gps.h` and `gps.cpp`. ACK messages are now processed through callback handlers.
 * **1.1.1**:
   - BUG FIX for acknowledgments. The last received ack message was accessed by multiple threads but was not atomic. This variable is now thread safe.
   - BUG FIX for GNSS configuration for Firmware 8, the GNSS configuration is now verified & modified properly.

--- a/README.md
+++ b/README.md
@@ -124,62 +124,63 @@ Navigation Satellite fix.
 
 Velocity in local ENU frame.
 
+## INF messages
+To enable printing INF messages to the ROS console, set the parameters below.
+* `inf/all`: This is the default value for the INF parameters below, which enable printing u-blox `INF` messages to the ROS console. It defaults to true. Individual message types can be turned off by setting their corresponding parameter to false.
+* `inf/debug`: Whether to configure the UBX and NMEA ports to send Debug messages and print received `INF-Debug` messages to `ROS_DEBUG` console.
+* `inf/error`: Whether to enable Error messages for the UBX and NMEA ports and print received `INF-Error` messages to `ROS_ERROR` console.
+* `inf/notice`: Whether to enable Notice messages for the UBX and NMEA ports and print received `INF-Notice messages to `ROS_INFO` console.
+* `inf/test`: Whether to enable Test messages for the UBX and NMEA ports and print received `INF-Test` messages to `ROS_INFO` console.
+* `inf/warning`: Whether to enable Warning messages for the UBX and NMEA ports and print received `INF-Warning` messages to the `ROS_WARN` console.
+
 ## Additional Topics
+To publish a given u-blox message to a ROS topic, set the parameter shown below to true. The node sets the rate of the u-blox messages to 1 measurement cycle. 
 
-To subscribe to the given topic set the parameter shown (e.g. `~inf`) to true.
-
-### INF messages
-* `inf/all`: This acts as the default value for the INF parameters below. It defaults to true. Individual messages can be turned off by setting the parameter below to false.
-* `inf/debug`: If true, configures UBX/NMEA ports to enable Debug messages and prints received INF Debug messages to `ROS_DEBUG` console.
-* `inf/error`: If true, configures UBX/NMEA ports to enable Error messages and prints received INF Error messages to `ROS_ERROR` console.
-* `inf/notice`: If true, configures UBX/NMEA ports to enable Notice messages and prints received INF Notice messages to `ROS_INFO` console.
-* `inf/test`: If true, configures UBX/NMEA ports to enable Test messages and prints received INF Test messages to `ROS_INFO` console.
-* `inf/warning`: If true, configures UBX/NMEA ports to enable Warning messages and prints received INF Warning messages to `ROS_WARN` console.
-
-### All message
-* `subscribe/all`:  This acts as the default value for the RXM, AID, MON, etc. `subscribe/<class>/all` parameters below. It defaults to false. Individual message classes and messages can be turned off by setting the parameter described below to false.
+### All messages
+* `publish/all`: This is the default value for `publish/<class>/all` parameters below. It defaults to false. Individual message classes and messages can be enabled or disabled by setting the parameters described below to false.
 
 ### AID messages
-* `subscribe/aid/all`: This acts as the default value for the AID subscriber parameters below. It defaults to true. Individual messages can be turned off by setting the parameter below to false.
-* `subscribe/aid/alm`: Topic `~aidalm`
-* `subscribe/aid/eph`: Topic `~aideph`
-* `subscribe/aid/hui`: Topic `~aidhui`
+* `publish/aid/all`: This is the default value for the `publish/aid/<message>` parameters below. It defaults to `publish/all`. Individual messages can be enabled or disabled by setting the parameters below.
+* `publish/aid/alm`: Topic `~aidalm`
+* `publish/aid/eph`: Topic `~aideph`
+* `publish/aid/hui`: Topic `~aidhui`
 
 ### RXM messages
-* `subscribe/rxm/all`: This acts as the default value for the RXM subscriber parameters below. It defaults to true. Individual messages can be turned off by setting the parameter below to false.
-* `subscribe/rxm/alm`: Topic `~rxmalm`
-* `subscribe/rxm/raw`: Topic `~rxmraw`
-* `subscribe/rxm/rtcm`: Topic `~rxmrtcm`
-* `subscribe/rxm/sfrb`: Topic `~rxmsfrb`
-* `subscribe/rxm/eph`: Topic `~rxmeph`
+* `publish/rxm/all`: This is the default value for the `publish/rxm/<message>` parameters below. It defaults to `publish/all`. Individual messages can be enabled or disabled by setting the parameters below.
+* `publish/rxm/alm`: Topic `~rxmalm`
+* `publish/rxm/eph`: Topic `~rxmeph`
+* `publish/rxm/raw`: Topic `~rxmraw`. Type is either `RxmRAW` or `RxmRAWX` depending on firmware version.
+* `publish/rxm/rtcm`: Topic `~rxmrtcm`. **Firmware >= 8 only**
+* `publish/rxm/sfrb`: Topic `~rxmsfrb`. Type is either `RxmSFRB` or `RxmSFRBX` depending on firmware version.
 
 ### MON messages
-* `subscribe/mon/all`: This acts as the default value for the MON subscriber parameters below. It defaults to true. Individual messages can be turned off by setting the parameter below to false.
-* `subscribe/mon/hw`: Topic `~monhw`
+* `publish/mon/all`: This is the default value for the `publish/mon/<message>` parameters below. It defaults to `publish/all`. Individual messages can be enabled or disabled by setting the parameters below.
+* `publish/mon/hw`: Topic `~monhw`
 
 ### NAV messages
-* `subscribe/nav/att`: Topic `~navatt` on ADR/UDR devices only
-* `subscribe/nav/clock`: Topic `~navclock`
-* `subscribe/nav/posecef`: Topic `~navposecef`
-* `subscribe/nav/posllh`: Topic `~navposllh`. Firmware <= 6 only. For 7 and above, use NavPVT
-* `subscribe/nav/pvt`: Topic `~navpvt`. Firmware >= 7 only.
-* `subscribe/nav/relposned`: Topic `~navrelposned`
-* `subscribe/nav/sat`: Topic `~navsat`
-* `subscribe/nav/sol`: Topic `~navsol`. Firmware <= 6 only. For 7 and above, use NavPVT
-* `subscribe/nav/status`: Topic `~navstatus`
-* `subscribe/nav/svin`: Topic `~navsvin`
-* `subscribe/nav/svinfo`: Topic `~navsvinfo`
-* `subscribe/nav/velned`: Topic `~navvelned`. Firmware <= 6 only. For 7 and above, use NavPVT
+* `publish/nav/all`: This is the default value for the `publish/mon/<message>` parameters below. It defaults to `publish/all`. Individual messages can be enabled or disabled by setting the parameters below.
+* `publish/nav/att`: Topic `~navatt`. **ADR/UDR devices only**
+* `publish/nav/clock`: Topic `~navclock`
+* `publish/nav/posecef`: Topic `~navposecef`
+* `publish/nav/posllh`: Topic `~navposllh`. **Firmware <= 6 only.** For firmware 7 and above, see NavPVT
+* `publish/nav/pvt`: Topic `~navpvt`. **Firmware >= 7 only.**
+* `publish/nav/relposned`: Topic `~navrelposned`. **HPG Rover devices only**
+* `publish/nav/sat`: Topic `~navsat`
+* `publish/nav/sol`: Topic `~navsol`. **Firmware <= 6 only.** For firmware 7 and above, see NavPVT
+* `publish/nav/status`: Topic `~navstatus`
+* `publish/nav/svin`: Topic `~navsvin`. **HPG Reference Station Devices only**
+* `publish/nav/svinfo`: Topic `~navsvinfo`
+* `publish/nav/velned`: Topic `~navvelned`. **Firmware <= 6 only.** For firmware 7 and above, see NavPVT
 
 ### ESF messages
-* `subscribe/esf/all`: This acts as the default value for the ESF subscriber parameters below. It defaults to true for ADR/UDR devices. Individual messages can be turned off by setting the parameter below to false.
-* `subscribe/esf/ins`: Topic `~esfins`
-* `subscribe/esf/meas`: Topic `~esfmeas`
-* `subscribe/esf/raw`: Topic `~esfraw`
-* `subscribe/esf/status`: Topic `~esfstatus`
+* `publish/esf/all`: This is the default value for the `publish/esf/<message>` parameters below. It defaults to `publish/all` for **ADR/UDR devices**. Individual messages can be enabled or disabled by setting the parameters below.
+* `publish/esf/ins`: Topic `~esfins`
+* `publish/esf/meas`: Topic `~esfmeas`
+* `publish/esf/raw`: Topic `~esfraw`
+* `publish/esf/status`: Topic `~esfstatus`
 
 ### HNR messages
-* `subscribe/hnr/pvt`: Topic `~hnrpvt`
+* `publish/hnr/pvt`: Topic `~hnrpvt`. **ADR/UDR devices only**
 
 ## Launch
 
@@ -190,9 +191,14 @@ The two topics to which you should subscribe are `~fix` and `~fix_velocity`. The
 
 * **1.1.2**:
   - BUG FIX for NavSatFix messages for firmware >=7. The NavSatFix now only uses the NavPVT message time if it is valid, otherwise it uses ROS time.
+  - BUG FIX for TMODE3 Fixed mode configuration. The ARP High Precision position is now configured correctly. 
   - Added `UBX-UPD` messages. For firmware version 8, the node can now save the flash memory on shutdown and clear the flash memory during configuration based on ROS params.
+  - Added `CfgGPS` message.
   - Added respawn parameters to example launch file.
   - Migrated all callback handling to `callback.h` from `gps.h` and `gps.cpp`. ACK messages are now processed through callback handlers.
+  - Modified how the I/O stream is initialized so that the node now handles parsing the port string.
+  - Cleaned up ublox custom serialization classes by adding typedefs and using count to determine repeating block statements instead of using try-catch statements to serialize stream.
+  - Added doxygen documentation
 * **1.1.1**:
   - BUG FIX for acknowledgments. The last received ack message was accessed by multiple threads but was not atomic. This variable is now thread safe.
   - BUG FIX for GNSS configuration for Firmware 8, the GNSS configuration is now verified & modified properly.

--- a/ublox/package.xml
+++ b/ublox/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package>
   <name>ublox</name>
-  <version>1.1.0</version>
-  <description>Provides a ublox_gps node for uBlox GPS receivers, messages, and serialization packages for the binary UBX protocol.</description>
+  <version>1.1.2</version>
+  <description>Provides a ublox_gps node for u-blox GPS receivers, messages, and serialization packages for the binary UBX protocol.</description>
   <author>Johannes Meyer</author>
   <maintainer email="vmlane@alum.mit.edu">Veronica Lane</maintainer>
   <license>BSD</license>

--- a/ublox_gps/config/c94_m8p_base.yaml
+++ b/ublox_gps/config/c94_m8p_base.yaml
@@ -2,6 +2,11 @@
 
 debug: 1                    # Range 0-4 (0 means no debug statements will print)
 
+save:
+  mask: 3103                # Save I/O, Message, INF Message, Nav, Receiver 
+                            # Manager, Antenna, and Logging Configuration
+  device: 4                 # Save to EEPROM
+
 device: /dev/ttyACM0
 frame_id: gps_base
 dynamic_model: stationary   # Velocity restricted to 0 m/s. Zero dynamics 
@@ -51,7 +56,6 @@ dat:
 
 # GNSS Config
 gnss:
-  reset_mode: 2             # Controlled Software reset
   glonass: true             # Supported by C94-M8P
   beidou: false             # Supported by C94-M8P
   qzss: false               # Supported by C94-M8P

--- a/ublox_gps/config/c94_m8p_base.yaml
+++ b/ublox_gps/config/c94_m8p_base.yaml
@@ -55,12 +55,14 @@ gnss:
   glonass: true             # Supported by C94-M8P
   beidou: false             # Supported by C94-M8P
   qzss: false               # Supported by C94-M8P
-  sbas: false               # Not supported by C94-M8P
 
-inf: true                   # Whether to display INF messages
+inf: 
+  all: true                   # Whether to display all INF messages in console
 
-# Message subscriptions
-subscribe:
+# Enable u-blox message publishers
+publish:
   all: true
   aid:
     hui: false
+  nav:
+    posecef: false

--- a/ublox_gps/config/c94_m8p_rover.yaml
+++ b/ublox_gps/config/c94_m8p_rover.yaml
@@ -26,26 +26,17 @@ gnss:
   glonass: true             # Supported by C94-M8P
   beidou: false             # Supported by C94-M8P
   qzss: false               # Supported by C94-M8P
-  sbas: false               # Not supported by C94-M8P
 
 dgnss_mode: 3               # Fixed mode
 
-inf: true                   # Whether to display INF messages
+inf: 
+  all: true                   # Whether to display all INF messages in console
 
-# Subscriptions
-subscribe:
+# Enable u-blox message publishers
+publish:
   all: true
-  aid: true
   aid:
     hui: false
 
   nav:
-    sol: true
-    pvt: true
-    status: true
-    svinfo: true
-    svin: true
-    clk: true
     posecef: false
-    velned: false
-    relposned: true

--- a/ublox_gps/config/c94_m8p_rover.yaml
+++ b/ublox_gps/config/c94_m8p_rover.yaml
@@ -2,6 +2,11 @@
 
 debug: 1                    # Range 0-4 (0 means no debug statements will print)
 
+save:
+  mask: 3103                # Save I/O, Message, INF Message, Nav, Receiver 
+                            # Manager, Antenna, and Logging Configuration
+  device: 4                 # Save to EEPROM
+
 device: /dev/ttyACM1
 frame_id: gps
 rate: 4                     # in Hz
@@ -22,7 +27,6 @@ uart1:
   out: 0                    # No UART out for rover
 
 gnss:
-  reset_mode: 2             # Controlled Software reset
   glonass: true             # Supported by C94-M8P
   beidou: false             # Supported by C94-M8P
   qzss: false               # Supported by C94-M8P

--- a/ublox_gps/include/ublox_gps/callback.h
+++ b/ublox_gps/include/ublox_gps/callback.h
@@ -36,9 +36,19 @@
 
 namespace ublox_gps {
 
+/**
+ * @brief A callback handler for a u-blox message.
+ */
 class CallbackHandler {
  public:
+  /**
+   * @brief Decode the u-blox message.
+   */
   virtual void handle(ublox::Reader& reader) = 0;
+
+  /**
+   * @brief Wait for on the condition.
+   */
   bool wait(const boost::posix_time::time_duration& timeout) {
     boost::mutex::scoped_lock lock(mutex_);
     return condition_.timed_wait(lock, timeout);
@@ -47,15 +57,24 @@ class CallbackHandler {
   boost::condition_variable condition_;
 };
 
+/**
+ * @brief A callback handler for a u-blox message.
+ * @typename T the message type
+ */
 template <typename T>
 class CallbackHandler_ : public CallbackHandler {
  public:
   typedef boost::function<void(const T&)> Callback;
+  /** 
+   * @brief Initialize the Callback Handler with a callback function
+   * @param func a callback function for the message, defaults to none
+   */
   CallbackHandler_(const Callback& func = Callback()) : func_(func) {}
   virtual const T& get() { return message_; }
 
   /**
    * @brief Decode the U-Blox message & call the callback function if it exists.
+   * @param reader a reader to decode the message buffer
    */
   void handle(ublox::Reader& reader) {
     boost::mutex::scoped_lock(mutex_);
@@ -88,6 +107,9 @@ class CallbackHandler_ : public CallbackHandler {
   T message_;
 };
 
+/**
+ * @brief A set of callback handlers used to handle incoming u-blox messages.
+ */
 class CallbackHandlers {
  public:
   /**

--- a/ublox_gps/include/ublox_gps/callback.h
+++ b/ublox_gps/include/ublox_gps/callback.h
@@ -89,9 +89,12 @@ class CallbackHandler_ : public CallbackHandler {
 };
 
 class CallbackHandlers {
-  typedef std::multimap<std::pair<uint8_t, uint8_t>,
-                        boost::shared_ptr<CallbackHandler> > Callbacks;
  public:
+  /**
+   * @brief Add a callback handler for the given message type.
+   * @param callback the callback handler for the message
+   * @typedef.a ublox_msgs message with CLASS_ID and MESSAGE_ID constants
+   */
   template <typename T>
   void insert(typename CallbackHandler_<T>::Callback callback) {
     boost::mutex::scoped_lock lock(callback_mutex_);
@@ -101,6 +104,14 @@ class CallbackHandlers {
                      boost::shared_ptr<CallbackHandler>(handler)));
   }
 
+  /**
+   * @brief Add a callback handler for the given message type and ID. This is 
+   * used for messages in which have the same structure (and therefore msg file)
+   * and same class ID but different message IDs. (e.g. INF, ACK)
+   * @param callback the callback handler for the message
+   * @param message_id the ID of the message
+   * @typedef.a ublox_msgs message with a CLASS_ID constant
+   */
   template <typename T>
   void insert(
       typename CallbackHandler_<T>::Callback callback, 
@@ -112,6 +123,10 @@ class CallbackHandlers {
                      boost::shared_ptr<CallbackHandler>(handler)));
   }
 
+  /**
+   * @brief Calls the callback handler for the message in the reader.
+   * @param reader a reader containing a u-blox message
+   */
   void handle(ublox::Reader& reader) {
     // Find the callback handlers for the message & decode it
     boost::mutex::scoped_lock lock(callback_mutex_);
@@ -122,6 +137,11 @@ class CallbackHandlers {
       callback->second->handle(reader);
   }
 
+  /**
+   * Read a u-blox message of the given type.
+   * @param message the received u-blox message
+   * @param timeout the amount of time to wait for the desired message
+   */
   template <typename T>
   bool read(T& message, const boost::posix_time::time_duration& timeout) {
     bool result = false;
@@ -146,7 +166,38 @@ class CallbackHandlers {
     return result;
   }
 
+  /**
+   * @brief Processes u-blox messages in the given buffer & clears the read
+   * messages from the buffer.
+   * @param data the buffer of u-blox messages to process
+   * @param size the size of the buffer
+   */
+  void readCallback(unsigned char* data, std::size_t& size) {
+    ublox::Reader reader(data, size);
+    // Read all U-Blox messages in buffer
+    while (reader.search() != reader.end() && reader.found()) {
+      if (debug >= 3) {
+        // Print the received bytes
+        std::ostringstream oss;
+        for (ublox::Reader::iterator it = reader.pos();
+             it != reader.pos() + reader.length() + 8; ++it)
+          oss << boost::format("%02x") % static_cast<unsigned int>(*it) << " ";
+        ROS_DEBUG("U-blox: reading %d bytes\n%s", reader.length() + 8, 
+                 oss.str().c_str());
+      }
+
+      handle(reader);
+    }
+
+    // delete read bytes from ASIO input buffer
+    std::copy(reader.pos(), reader.end(), data);
+    size -= reader.pos() - data;
+  }
+
  private:
+  typedef std::multimap<std::pair<uint8_t, uint8_t>,
+                        boost::shared_ptr<CallbackHandler> > Callbacks;
+
   // Call back handlers for u-blox messages
   Callbacks callbacks_;
   boost::mutex callback_mutex_;

--- a/ublox_gps/include/ublox_gps/callback.h
+++ b/ublox_gps/include/ublox_gps/callback.h
@@ -53,23 +53,30 @@ class CallbackHandler {
     boost::mutex::scoped_lock lock(mutex_);
     return condition_.timed_wait(lock, timeout);
   }
-  boost::mutex mutex_;
-  boost::condition_variable condition_;
+
+ protected:
+  boost::mutex mutex_; //!< Lock for the handler
+  boost::condition_variable condition_; //!< Condition for the handler lock
 };
 
 /**
  * @brief A callback handler for a u-blox message.
- * @typename T the message type
+ * @typedef T the message type
  */
 template <typename T>
 class CallbackHandler_ : public CallbackHandler {
  public:
-  typedef boost::function<void(const T&)> Callback;
+  typedef boost::function<void(const T&)> Callback; //!< A callback function
+
   /** 
    * @brief Initialize the Callback Handler with a callback function
    * @param func a callback function for the message, defaults to none
    */
   CallbackHandler_(const Callback& func = Callback()) : func_(func) {}
+  
+  /**
+   * @brief Get the last received message.
+   */
   virtual const T& get() { return message_; }
 
   /**
@@ -103,12 +110,12 @@ class CallbackHandler_ : public CallbackHandler {
   }
   
  private:
-  Callback func_;
-  T message_;
+  Callback func_; //!< the callback function to handle the message
+  T message_; //!< The last received message
 };
 
 /**
- * @brief A set of callback handlers used to handle incoming u-blox messages.
+ * @brief Callback handlers for incoming u-blox messages.
  */
 class CallbackHandlers {
  public:
@@ -160,7 +167,7 @@ class CallbackHandlers {
   }
 
   /**
-   * Read a u-blox message of the given type.
+   * @brief Read a u-blox message of the given type.
    * @param message the received u-blox message
    * @param timeout the amount of time to wait for the desired message
    */

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -99,10 +99,17 @@ class Gps {
    * @param uart_in the UART In protocol, see CfgPRT for options
    * @param uart_out the UART Out protocol, see CfgPRT for options
    */
-  void initializeSerial(std::string port,
-                        unsigned int baudrate,
-                        uint16_t uart_in,
-                        uint16_t uart_out);
+  void initializeSerial(std::string port, unsigned int baudrate,
+                        uint16_t uart_in, uint16_t uart_out);
+
+  /**
+   * @brief Reset the Serial I/O port after u-blox reset.
+   * @param port the device port address
+   * @param baudrate the desired baud rate of the port
+   * @param uart_in the UART In protocol, see CfgPRT for options
+   * @param uart_out the UART Out protocol, see CfgPRT for options
+   */
+  void resetSerial(std::string port);
 
   /**
    * @brief Closes the I/O port, and initiates save on shutdown procedure
@@ -111,12 +118,28 @@ class Gps {
   void close();
 
   /**
-   * @brief Send a reset message to the u-blox-device
+   * @brief Reset I/O communications.
+   * @param wait Time to wait before restarting communications
+   */
+  void reset(const boost::posix_time::time_duration& wait);
+
+  /**
+   * @brief Send a reset message to the u-blox device.
    * @param nav_bbr_mask The BBR sections to clear, see CfgRST message
    * @param reset_mode The reset type, see CfgRST message
    * @return true if the message was successfully sent, false otherwise
    */
-  bool reset(uint16_t nav_bbr_mask, uint16_t reset_mode);
+  bool configReset(uint16_t nav_bbr_mask, uint16_t reset_mode);
+
+  /**
+   * @brief Configure the GNSS, cold reset the device, and reset the I/O.
+   * @param gnss the desired GNSS configuration
+   * @param wait the time to wait after resetting I/O before restarting
+   * @return true if the GNSS was configured, the device was reset, and the 
+   * I/O reset successfully
+   */
+  bool configGnss(ublox_msgs::CfgGNSS gnss, 
+                  const boost::posix_time::time_duration& wait);
 
   /**
    * @brief Send a message to the receiver to delete the BBR data stored in 
@@ -124,7 +147,7 @@ class Gps {
    * @return true if sent message and received ACK, false otherwise
    */
   bool clearBbr();
-  
+
   /**
    * @brief Configure the UART1 Port.
    * @param baudrate the baudrate of the port
@@ -421,6 +444,8 @@ class Gps {
 
   //! Callback handlers for u-blox messages
   CallbackHandlers callbacks_; 
+
+  std::string host_, port_;
 };
 
 template <typename T>

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -123,7 +123,7 @@ class Gps {
   
   /**
    * @brief Configure the UART1 Port.
-   * @param ids the baudrate of the port
+   * @param baudrate the baudrate of the port
    * @param in_proto_mask the in protocol mask, see CfgPRT message
    * @param out_proto_mask the out protocol mask, see CfgPRT message
    * @return true on ACK, false on other conditions.
@@ -139,6 +139,16 @@ class Gps {
    * @return true on ACK, false on other conditions.
    */
   bool disableUart1(ublox_msgs::CfgPRT& prev_cfg);
+
+  /**
+   * @brief Configure the USB Port.
+   * @param tx_ready the TX ready pin configuration, see CfgPRT message
+   * @param in_proto_mask the in protocol mask, see CfgPRT message
+   * @param out_proto_mask the out protocol mask, see CfgPRT message
+   * @return true on ACK, false on other conditions.
+   */
+  bool configUsb(uint16_t tx_ready, uint16_t in_proto_mask,
+                 uint16_t out_proto_mask);
 
   /**
    * @brief Configure the device navigation and measurement rate settings.

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -333,6 +333,29 @@ class Gps {
   };
 
   void setWorker(const boost::shared_ptr<Worker>& worker);
+
+  /**
+   * @brief Subscribe to ACK/NACK messages and UPD-SOS-ACK messages.
+   */
+  void subscribeAcks();
+
+  /**
+   * @brief Callback handler for UBX-ACK message.
+   * @param m the message to process
+   */
+  void processAck(const ublox_msgs::Ack &m);
+  
+  /**
+   * @brief Callback handler for UBX-NACK message.
+   * @param m the message to process
+   */
+  void processNack(const ublox_msgs::Ack &m);
+
+  /**
+   * @brief Callback handler for UBX-UPD-SOS-ACK message.
+   * @param m the message to process
+   */
+  void processUpdSosAck(const ublox_msgs::UpdSOS_Ack &m);
   
   /**
    * @brief Initialize TCP I/O.
@@ -348,13 +371,6 @@ class Gps {
   void initializeSerial(unsigned int baudrate,
                         uint16_t uart_in,
                         uint16_t uart_out);
-  /**
-   * @brief Processes u-blox messages in the given buffer & clears the read
-   * messages from the buffer.
-   * @param data the buffer of u-blox messages to process
-   * @param size the size of the buffer
-   */
-  void readCallback(unsigned char* data, std::size_t& size);
 
   /**
    * @brief Send a stop message to the receiver and instruct it to dump its 
@@ -377,7 +393,7 @@ class Gps {
   // Stores last received ACK, accessed by multiple threads
   mutable boost::atomic<Ack> ack_;
 
-  // Call back handlers for u-blox messages
+  // Callback handlers for u-blox messages
   CallbackHandlers callbacks_;
 
   // Asynchronous IO objects

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -158,14 +158,15 @@ class Gps {
    * @param arp_position a vector of size 3 representing the ARP position in 
    * ECEF coordinates [m] or LLA coordinates [deg]
    * @param arp_position_hp a vector of size 3 a vector of size 3 representing  
-   * the ARP position in ECEF coordinates [m] or LLA coordinates [deg]
+   * the ARP position in ECEF coordinates [0.1 mm] or LLA coordinates 
+   * [deg * 1e-9]
    * @param lla_flag true if position is given in LAT/LON/ALT, false if ECEF
    * @param fixed_pos_acc Fixed position 3D accuracy [m]
    * @return true on ACK, false if settings are incorrect or on other conditions
    */
   bool configTmode3Fixed(bool lla_flag,
                          std::vector<float> arp_position, 
-                         std::vector<float> arp_position_hp,
+                         std::vector<int8_t> arp_position_hp,
                          float fixed_pos_acc);
 
   /**

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -49,18 +49,24 @@
 #include <ublox_gps/callback.h>
 
 namespace ublox_gps {
-// Possible baudrates for u-blox devices
-const static unsigned int kBaudrates[] = {4800, 9600, 19200, 38400, 
-                                          57600, 115200, 230400, 460800};
+const static unsigned int kBaudrates[] = {4800, 
+                                          9600, 
+                                          19200, 
+                                          38400, 
+                                          57600, 
+                                          115200, 
+                                          230400, 
+                                          460800}; //!< Possible baudrates for 
+                                                   //!< u-blox devices
 
 class Gps {
  public:
-  // Sleep time [ms] after setting the baudrate
-  const static int kSetBaudrateSleepMs = 500;
-  // Default timeout for ACK messages in seconds
-  const static double kDefaultAckTimeout = 1.0;
-  // Size of write buffer for output messages
-  const static int kWriterSize = 1024;
+  const static int kSetBaudrateSleepMs = 500; //!< Sleep time [ms] after setting 
+                                              //!< the baudrate
+  const static double kDefaultAckTimeout = 1.0; //!< Default timeout for ACK 
+                                                //!< messages in seconds
+  const static int kWriterSize = 1024; //!< Size of write buffer for output 
+                                       //!< messages
 
   Gps();
   virtual ~Gps();
@@ -152,9 +158,10 @@ class Gps {
   bool configSbas(bool enable, uint8_t usage, uint8_t max_sbas);
 
   /**
-   * @brief Set the TMODE3 settings to fixed at the given antenna reference
-   * point (ARP) position in either Latitude Longitude Altitude (LLA) or 
-   * ECEF coordinates.
+   * @brief Set the TMODE3 settings to fixed.
+   * 
+   * @details Sets the at the given antenna reference point (ARP) position in 
+   * either Latitude Longitude Altitude (LLA) or ECEF coordinates.
    * @param arp_position a vector of size 3 representing the ARP position in 
    * ECEF coordinates [m] or LLA coordinates [deg]
    * @param arp_position_hp a vector of size 3 a vector of size 3 representing  
@@ -382,18 +389,15 @@ class Gps {
   bool saveOnShutdown();
 
   boost::shared_ptr<Worker> worker_;
-  // Whether or not the I/O port has been configured 
-  bool configured_;
-  // Whether or not to call save on shutdown upon shutdown
-  bool save_on_shutdown_;
+  bool configured_; //!< Whether or not the I/O port has been configured
+  bool save_on_shutdown_; //!< Whether or not to save Flash BBR on shutdown
 
   // The default timeout for ACK messages
   static boost::posix_time::time_duration default_timeout_;
-  // Stores last received ACK, accessed by multiple threads
-  mutable boost::atomic<Ack> ack_;
+  mutable boost::atomic<Ack> ack_; //!< Stores last received ACK
+                                   //!< accessed by multiple threads
 
-  // Callback handlers for u-blox messages
-  CallbackHandlers callbacks_;
+  CallbackHandlers callbacks_; //!< Callback handlers for u-blox messages
 
   // Asynchronous IO objects
   boost::asio::io_service io_service_;

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -40,8 +40,6 @@
 #include <boost/regex.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/atomic.hpp>
-#include <boost/thread/mutex.hpp>
-
 
 #include <ros/console.h>
 

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -29,25 +29,29 @@
 
 #ifndef UBLOX_GPS_H
 #define UBLOX_GPS_H
-
+// STL
 #include <map>
 #include <vector>
 #include <locale>
 #include <stdexcept>
-
+// Boost
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/serial_port.hpp>
-#include <boost/regex.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/atomic.hpp>
-
+// ROS
 #include <ros/console.h>
-
+// Other u-blox packages
 #include <ublox/serialization/ublox_msgs.h>
-
+// u-blox gps
 #include <ublox_gps/async_worker.h>
 #include <ublox_gps/callback.h>
 
+/**
+ * @namespace ublox_gps
+ * This namespace is for I/O communication with the u-blox device, including
+ * read callbacks. 
+ */
 namespace ublox_gps {
 //! Possible baudrates for u-blox devices
 const static unsigned int kBaudrates[] = { 4800, 

--- a/ublox_gps/include/ublox_gps/mkgmtime.h
+++ b/ublox_gps/include/ublox_gps/mkgmtime.h
@@ -46,6 +46,10 @@
 
 #include <time.h>
 
+/**
+ * @brief Get the UTC time in seconds and nano-seconds from a time struct in
+ * GM time.
+ */
 extern time_t mkgmtime(struct tm * const tmp);
 
 #endif /* INCLUDED_MKGMTIME_H */

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -505,7 +505,16 @@ class UbloxNode : public virtual ComponentInterface {
   //! UART in protocol (see CfgPRT message for constants)
   uint16_t uart_in_; 
   //! UART out protocol (see CfgPRT message for constants)
-  uint16_t uart_out_; 
+  uint16_t uart_out_;
+  //! USB TX Ready Pin configuration (see CfgPRT message for constants)
+  uint16_t usb_tx_;
+  //! Whether to configure the USB port 
+  /*! Set to true if usb_in & usb_out parameters are set */
+  bool set_usb_;
+  //! USB in protocol (see CfgPRT message for constants)
+  uint16_t usb_in_;
+  //! USB out protocol (see CfgPRT message for constants)
+  uint16_t usb_out_ ;
   //! The measurement rate in Hz
   double rate_; 
   //! If true, set configure the User-Defined Datum

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -189,7 +189,7 @@ bool checkRange(std::vector<V> val, T min, T max, std::string name) {
  * @returns true if found, false if not found.
  */
 template <typename U>
-bool getRosParam(const std::string& key, U &u) {
+bool getRosUint(const std::string& key, U &u) {
   int param;
   if (!nh->getParam(key, param)) return false;
   // Check the bounds
@@ -210,8 +210,8 @@ bool getRosParam(const std::string& key, U &u) {
  * @returns true if found, false if not found.
  */
 template <typename U, typename V>
-void getRosParam(const std::string& key, U &u, V default_val) {
-  if(!getRosParam(key, u))
+void getRosUint(const std::string& key, U &u, V default_val) {
+  if(!getRosUint(key, u))
     u = default_val;
 }
 
@@ -221,7 +221,7 @@ void getRosParam(const std::string& key, U &u, V default_val) {
  * @returns true if found, false if not found.
  */
 template <typename U>
-bool getRosParam(const std::string& key, std::vector<U> &u) {
+bool getRosUint(const std::string& key, std::vector<U> &u) {
   std::vector<int> param;
   if (!nh->getParam(key, param)) return false;
   
@@ -232,6 +232,60 @@ bool getRosParam(const std::string& key, std::vector<U> &u) {
 
   // set the output
   u.insert(u.begin(), param.begin(), param.end());
+  return true;
+}
+
+/**
+ * @brief Get a integer (size 8 or 16) value from the parameter server.
+ * @param key the key to be used in the parameter server's dictionary
+ * @param u storage for the retrieved value.
+ * @throws std::runtime_error if the parameter is out of bounds
+ * @returns true if found, false if not found.
+ */
+template <typename I>
+bool getRosInt(const std::string& key, I &u) {
+  int param;
+  if (!nh->getParam(key, param)) return false;
+  // Check the bounds
+  I min = 1 << (sizeof(I) * 8 - 1);
+  I max = (I)~(min);
+  checkRange(param, min, max, key);
+  // set the output
+  u = (I) param;
+  return true;
+}
+
+/**
+ * @brief Get an integer value (size 8 or 16) from the parameter server.
+ * @param key the key to be used in the parameter server's dictionary
+ * @param u storage for the retrieved value.
+ * @param val value to use if the server doesn't contain this parameter.
+ * @throws std::runtime_error if the parameter is out of bounds
+ * @returns true if found, false if not found.
+ */
+template <typename U, typename V>
+void getRosInt(const std::string& key, U &u, V default_val) {
+  if(!getRosInt(key, u))
+    u = default_val;
+}
+
+/**
+ * @brief Get a int (size 8 or 16) vector from the parameter server.
+ * @throws std::runtime_error if the parameter is out of bounds.
+ * @returns true if found, false if not found.
+ */
+template <typename I>
+bool getRosInt(const std::string& key, std::vector<I> &i) {
+  std::vector<int> param;
+  if (!nh->getParam(key, param)) return false;
+  
+  // Check the bounds
+  I min = 1 << (sizeof(I) * 8 - 1);
+  I max = (I)~(min);
+  checkRange(param, min, max, key);
+
+  // set the output
+  i.insert(i.begin(), param.begin(), param.end());
   return true;
 }
 
@@ -857,10 +911,10 @@ class UbloxHpgRef: public virtual ComponentInterface {
   // TMODE3 = Fixed mode settings
   // True if coordinates are in LLA, false if ECEF
   bool lla_flag_; 
-  // Antenna Reference Point Position [m]
+  // Antenna Reference Point Position [m] or [deg]
   std::vector<float> arp_position_;
-  // Antenna Reference Point Position - High Precision [0.1 mm]
-  std::vector<float> arp_position_hp_;
+  // Antenna Reference Point Position - High Precision [0.1 mm] or [deg * 1e-9]
+  std::vector<int8_t> arp_position_hp_;
   // Fixed Position Accuracy [m]
   float fixed_pos_acc_;
   

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -355,6 +355,11 @@ class UbloxNode : public virtual ComponentInterface {
   void initialize();
 
   /**
+   * @brief Shutdown the node. Closes the serial port.
+   */
+  void shutdown();
+
+  /**
    * @brief Send a reset message the u-blox device & re-initialize the I/O.
    * @return true if reset was successful, false otherwise.
    */
@@ -397,23 +402,27 @@ class UbloxNode : public virtual ComponentInterface {
   double min_freq, max_freq;
 
   // Variables set from parameter server
+  // Device port, dynamic model type, and fix mode type
   std::string device_, dynamic_model_, fix_mode_;
   // Set from dynamic model & fix mode strings
   uint8_t dmodel_, fmode_;
   // UART1 baudrate and in/out protocol (see CfgPRT message for constants)
   uint32_t baudrate_;
   uint16_t uart_in_, uart_out_; 
+  // The measurement rate in Hz
   double rate_;
-  // User-defined Datum (only used if the set_dat param is true)
+  // If true, set configure the User-Defined Datum
   bool set_dat_;
+  // User-defined Datum 
   ublox_msgs::CfgDAT cfg_dat_;
-  // If true: enable the GNSS
+  // If true: enable the feature
   bool enable_sbas_, enable_ppp_;
+  // SBAS parameters (see CfgSBAS) and dead reckoning LIMITED
   uint8_t sbas_usage_, max_sbas_, dr_limit_;
 
   // Determined From Mon VER
   float protocol_version_;
-
+  
   // The node will call the functions in these interfaces for each object
   // in the vector, this allows the user to easily add new features
   std::vector<boost::shared_ptr<ComponentInterface> > components_;
@@ -718,9 +727,15 @@ class UbloxFirmware8 : public UbloxFirmware7Plus<ublox_msgs::NavPVT> {
   // Type of device reset, only used if GNSS configuration is changed
   // see CfgRST message for constants
   uint8_t reset_mode_;
-  // Used to configure NMEA (if set_nmea_), filled with ros params
-  ublox_msgs::CfgNMEA cfg_nmea_;
+  // If true, the node will configure the NMEA settings
   bool set_nmea_;
+  // Desired NMEA configuration, set from ROS parameters
+  ublox_msgs::CfgNMEA cfg_nmea_;
+  // If true, node will send command to saves the BBR to flash memory on 
+  // shutdown
+  bool save_on_shutdown_;
+  // If true, node will send command to clear the flash memory during config
+  bool clear_bbr_;
 };
 
 /**

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -74,36 +74,41 @@
 
 namespace ublox_node {
 
-const static uint32_t kROSQueueSize = 1; //!< Queue size for ROS publishers
-const static uint16_t kDefaultMeasPeriod = 250; //!< Default measurement period
-                                                //!< for HPG devices
-const static uint32_t kSubscribeRate = 1; //!< Default subscribe Rate to u-blox 
-                                          //!< messages [Hz]
-const static uint32_t kNavSvInfoSubscribeRate = 20; //!< Subscribe Rate for 
-                                                    //!< u-blox SV Info messages
+//! Queue size for ROS publishers
+const static uint32_t kROSQueueSize = 1; 
+//! Default measurement period for HPG devices
+const static uint16_t kDefaultMeasPeriod = 250; 
+//! Default subscribe Rate to u-blox messages [Hz]
+const static uint32_t kSubscribeRate = 1; 
+//! Subscribe Rate for u-blox SV Info messages
+const static uint32_t kNavSvInfoSubscribeRate = 20; 
 
 // ROS objects
-boost::shared_ptr<diagnostic_updater::Updater> updater; //!< ROS diagnostic 
-                                                        //!< updater
-boost::shared_ptr<diagnostic_updater::TopicDiagnostic> freq_diag; //!< fix 
-                                                                 //!< frequency
-                                                                 //!< diagnostic
-                                                                 //!< updater
-boost::shared_ptr<ros::NodeHandle> nh; //!< Node Handle for GPS node
+//! ROS diagnostic updater
+boost::shared_ptr<diagnostic_updater::Updater> updater; 
+//! fix frequency diagnostic updater
+boost::shared_ptr<diagnostic_updater::TopicDiagnostic> freq_diag; 
+//! Node Handle for GPS node
+boost::shared_ptr<ros::NodeHandle> nh; 
 
-ublox_gps::Gps gps; //!< Handles communication with the U-Blox Device
-std::set<std::string> supported; //!< Which GNSS are supported by the device
-std::map<std::string, bool> enabled; //!< Whether or not to enable the given 
-                                     //!< message subscriber
-std::string frame_id; //!< The ROS frame ID of this GPS
-int fix_status_service; //!< The fix status service type, set based on the 
-                        //!< enabled GNSS
-uint16_t meas_rate; //!< The measurement [ms], see CfgRate.msg
-uint16_t nav_rate; //!< Navigation rate in measurement cycles, see CfgRate.msg
-std::vector<uint8_t> rtcm_ids; //!< IDs of RTCM out messages to 
-                               //!< configure
-std::vector<uint8_t> rtcm_rates; //!< Rates of RTCM out messages. Size must be  
-                                 //!< the same as rtcm_ids
+//! Handles communication with the U-Blox Device
+ublox_gps::Gps gps; 
+//! Which GNSS are supported by the device
+std::set<std::string> supported; 
+//! Whether or not to enable the given message subscriber
+std::map<std::string, bool> enabled; 
+//! The ROS frame ID of this GPS
+std::string frame_id; 
+//! The fix status service type, set based on the enabled GNSS
+int fix_status_service; 
+//! The measurement [ms], see CfgRate.msg
+uint16_t meas_rate; 
+//! Navigation rate in measurement cycles, see CfgRate.msg
+uint16_t nav_rate; 
+//! IDs of RTCM out messages to configure
+std::vector<uint8_t> rtcm_ids; 
+//! Rates of RTCM out messages. Size must be the same as rtcm_ids
+std::vector<uint8_t> rtcm_rates; 
 
 /**
  * @brief Determine dynamic model from human-readable string.
@@ -189,7 +194,7 @@ bool checkRange(std::vector<V> val, T min, T max, std::string name) {
  * @param key the key to be used in the parameter server's dictionary
  * @param u storage for the retrieved value.
  * @throws std::runtime_error if the parameter is out of bounds
- * @returns true if found, false if not found.
+ * @return true if found, false if not found.
  */
 template <typename U>
 bool getRosUint(const std::string& key, U &u) {
@@ -210,7 +215,7 @@ bool getRosUint(const std::string& key, U &u) {
  * @param u storage for the retrieved value.
  * @param val value to use if the server doesn't contain this parameter.
  * @throws std::runtime_error if the parameter is out of bounds
- * @returns true if found, false if not found.
+ * @return true if found, false if not found.
  */
 template <typename U, typename V>
 void getRosUint(const std::string& key, U &u, V default_val) {
@@ -221,7 +226,7 @@ void getRosUint(const std::string& key, U &u, V default_val) {
 /**
  * @brief Get a unsigned integer vector from the parameter server.
  * @throws std::runtime_error if the parameter is out of bounds.
- * @returns true if found, false if not found.
+ * @return true if found, false if not found.
  */
 template <typename U>
 bool getRosUint(const std::string& key, std::vector<U> &u) {
@@ -243,7 +248,7 @@ bool getRosUint(const std::string& key, std::vector<U> &u) {
  * @param key the key to be used in the parameter server's dictionary
  * @param u storage for the retrieved value.
  * @throws std::runtime_error if the parameter is out of bounds
- * @returns true if found, false if not found.
+ * @return true if found, false if not found.
  */
 template <typename I>
 bool getRosInt(const std::string& key, I &u) {
@@ -264,7 +269,7 @@ bool getRosInt(const std::string& key, I &u) {
  * @param u storage for the retrieved value.
  * @param val value to use if the server doesn't contain this parameter.
  * @throws std::runtime_error if the parameter is out of bounds
- * @returns true if found, false if not found.
+ * @return true if found, false if not found.
  */
 template <typename U, typename V>
 void getRosInt(const std::string& key, U &u, V default_val) {
@@ -275,7 +280,7 @@ void getRosInt(const std::string& key, U &u, V default_val) {
 /**
  * @brief Get a int (size 8 or 16) vector from the parameter server.
  * @throws std::runtime_error if the parameter is out of bounds.
- * @returns true if found, false if not found.
+ * @return true if found, false if not found.
  */
 template <typename I>
 bool getRosInt(const std::string& key, std::vector<I> &i) {
@@ -333,7 +338,7 @@ class ComponentInterface {
   
   /**
    * @brief Configure the U-Blox settings.
-   * @returns true if configured correctly, false otherwise
+   * @return true if configured correctly, false otherwise
    */
   virtual bool configureUblox() = 0;
 
@@ -369,16 +374,17 @@ typedef boost::shared_ptr<ComponentInterface> ComponentPtr;
  */
 class UbloxNode : public virtual ComponentInterface {
  public:
-  const static double kPollDuration = 1.0; //!< how often (in seconds) to 
-                                           //!< call poll messages
+  //! how often (in seconds) to call poll messages
+  const static double kPollDuration = 1.0; 
   // Constants used for diagnostic frequency updater
-  const static float kDiagnosticPeriod = 0.2; //!< [s] 5Hz diagnostic period
-  const static double kFixFreqTol = 0.15; //!< Tolerance for Fix topic frequency 
-                                          //!< as percentage of target frequency
-  const static double kFixFreqWindow = 10; //!< Window [num messages] for 
-                                           //!< Fix Frequency Diagnostic
-  const static double kTimeStampStatusMin = 0; //!< Minimum Time Stamp Status
-                                               //!< for fix frequency diagnostic
+  //! [s] 5Hz diagnostic period
+  const static float kDiagnosticPeriod = 0.2; 
+  //! Tolerance for Fix topic frequency as percentage of target frequency
+  const static double kFixFreqTol = 0.15; 
+  //! Window [num messages] for Fix Frequency Diagnostic
+  const static double kFixFreqWindow = 10; 
+  //! Minimum Time Stamp Status for fix frequency diagnostic
+  const static double kTimeStampStatusMin = 0; 
 
   /**
    * @brief Initialize and run the u-blox node.
@@ -396,7 +402,7 @@ class UbloxNode : public virtual ComponentInterface {
    */
   bool configureUblox();
 
-  /*
+  /**
    * @brief Subscribe to all requested u-blox messages.
    */
   void subscribe();
@@ -407,11 +413,17 @@ class UbloxNode : public virtual ComponentInterface {
   void initializeRosDiagnostics();
 
   /**
-   * @brief Prints an INF message to the ROS console.
+   * @brief Print an INF message to the ROS console.
    */
   void printInf(const ublox_msgs::Inf &m, uint8_t id);
 
  private:
+
+  /**
+   * @brief Initialize the I/O handling.
+   */
+  void initializeIo();
+  
   /**
    * @brief Initialize the U-Blox node. Configure the U-Blox and subscribe to 
    * messages.
@@ -430,8 +442,9 @@ class UbloxNode : public virtual ComponentInterface {
   bool resetDevice();
 
   /**
-   * Process the MonVer message. Find the protocol version, hardware type and 
-   * supported GNSS. Add the appropriate firmware and product components.
+   * @brief Process the MonVer message and add firmware and product components.
+   *
+   * @details Determines the protocol version, product type and supported GNSS.
    */
   void processMonVer();
 
@@ -461,36 +474,58 @@ class UbloxNode : public virtual ComponentInterface {
    * @brief Configure INF messages, call after subscribe.
    */
   void configureInf();
-
-  double min_freq; //!< Used for diagnostic updater, set from constants
-  double max_freq; //!< Used for diagnostic updater, set from constants
-
-  // Variables set from parameter server
-  std::string device_; //!< Device port
-  std::string dynamic_model_; //!< dynamic model type
-  std::string fix_mode_; //!< Fix mode type
-  uint8_t dmodel_; //!< Set from dynamic model string
-  uint8_t fmode_; //!< Set from fix mode string
-  uint32_t baudrate_; //!< UART1 baudrate
-  uint16_t uart_in_; //!< UART in protocol (see CfgPRT message for constants)
-  uint16_t uart_out_; //!< UART out protocol (see CfgPRT message for constants)
-  double rate_; //!< The measurement rate in Hz
-  bool set_dat_; //!< If true, set configure the User-Defined Datum
-  ublox_msgs::CfgDAT cfg_dat_; //!< User-defined Datum
-  bool enable_sbas_; //!< Whether or not to enable SBAS
-  bool enable_ppp_; //!< Whether or not to enable PPP (advanced setting)
-  // SBAS parameters (see CfgSBAS) and dead reckoning LIMITED
-  uint8_t sbas_usage_, max_sbas_, dr_limit_;
-
-  float protocol_version_; //!< Determined From Mon VER
   
-  // The node will call the functions in these interfaces for each object
-  // in the vector, this allows the user to easily add new features
+  //! The u-blox node components
+  /*! 
+   * The node will call the functions in these interfaces for each object
+   * in the vector.
+   */
   std::vector<boost::shared_ptr<ComponentInterface> > components_;
+
+  //! Used for diagnostic updater, set from constants
+  double min_freq;
+  //! Used for diagnostic updater, set from constants
+  double max_freq; 
+
+  //! Determined From Mon VER
+  float protocol_version_; 
+  // Variables set from parameter server
+  //! Device port
+  std::string device_; 
+  //! dynamic model type
+  std::string dynamic_model_; 
+  //! Fix mode type
+  std::string fix_mode_; 
+  //! Set from dynamic model string
+  uint8_t dmodel_; 
+  //! Set from fix mode string
+  uint8_t fmode_; 
+  //! UART1 baudrate
+  uint32_t baudrate_; 
+  //! UART in protocol (see CfgPRT message for constants)
+  uint16_t uart_in_; 
+  //! UART out protocol (see CfgPRT message for constants)
+  uint16_t uart_out_; 
+  //! The measurement rate in Hz
+  double rate_; 
+  //! If true, set configure the User-Defined Datum
+  bool set_dat_; 
+  //! User-defined Datum
+  ublox_msgs::CfgDAT cfg_dat_; 
+  //! Whether or not to enable SBAS
+  bool enable_sbas_; 
+  //! Whether or not to enable PPP (advanced setting)
+  bool enable_ppp_; 
+  //! SBAS Usage parameter (see CfgSBAS message) 
+  uint8_t sbas_usage_;
+  //! Max SBAS parameter (see CfgSBAS message) 
+  uint8_t max_sbas_;
+  //! Dead reckoning limit parameter
+  uint8_t dr_limit_;
 };
 
 /** 
- * @brief This abstract class is represents a firmware component.
+ * @brief This abstract class represents a firmware component.
  * 
  * @details The Firmware components update the fix diagnostics.
  */
@@ -510,7 +545,7 @@ class UbloxFirmware : public virtual ComponentInterface {
 };
 
 /**
- * @brief u-blox functionality for firmware version 6.
+ * @brief Implements functions for firmware version 6.
  */
 class UbloxFirmware6 : public UbloxFirmware {
  public:
@@ -523,12 +558,12 @@ class UbloxFirmware6 : public UbloxFirmware {
 
   /**
    * @brief Prints a warning, GNSS configuration not available in this version.
-   * @returns true if configured correctly, false otherwise
+   * @return true if configured correctly, false otherwise
    */
   bool configureUblox();
 
   /**
-   * @brief Subscribes to NavPVT, RxmRAW, and RxmSFRB messages. 
+   * @brief Subscribe to NavPVT, RxmRAW, and RxmSFRB messages. 
    */
   void subscribe();
 
@@ -540,46 +575,51 @@ class UbloxFirmware6 : public UbloxFirmware {
   void fixDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
   
  private:
-  /*
+  /**
    * @brief Publish a NavPOSLLh message & update the fix diagnostics & 
    * last known position.
    * @param m the message to publish
    */
   void publishNavPosLlh(const ublox_msgs::NavPOSLLH& m);
   
-  /*
+  /**
    * @brief Publish a NavVELNED message & update the last known velocity.
    * @param m the message to publish
    */
   void publishNavVelNed(const ublox_msgs::NavVELNED& m);
 
-  /*
+  /**
    * @brief Publish a NavSOL message and update the number of SVs used for the 
    * fix.
    * @param m the message to publish
    */
   void publishNavSol(const ublox_msgs::NavSOL& m);
 
-  ublox_msgs::NavPOSLLH last_nav_pos_; //!< The last received navigation 
-                                       //!< position
-  ublox_msgs::NavVELNED last_nav_vel_; //!< The last received navigation 
-                                       //!< velocity
-  ublox_msgs::NavSOL last_nav_sol_; //!< The last received num SVs used
-  sensor_msgs::NavSatFix fix_; //!< The last NavSatFix based on last_nav_pos_
-  geometry_msgs::TwistWithCovarianceStamped velocity_; //!< The last Twist based 
-                                                       //!< on last_nav_vel_
+  //! The last received navigation position
+  ublox_msgs::NavPOSLLH last_nav_pos_; 
+  //! The last received navigation velocity
+  ublox_msgs::NavVELNED last_nav_vel_; 
+  //! The last received num SVs used
+  ublox_msgs::NavSOL last_nav_sol_; 
+  //! The last NavSatFix based on last_nav_pos_
+  sensor_msgs::NavSatFix fix_; 
+  //! The last Twist based on last_nav_vel_
+  geometry_msgs::TwistWithCovarianceStamped velocity_; 
 
-  ublox_msgs::CfgNMEA6 cfg_nmea_; //!< Used to configure NMEA (if set_nmea_)
-                                  //!< filled with ROS parameters
-  bool set_nmea_; //!< Whether or not to configure the NMEA settings
+  //! Used to configure NMEA (if set_nmea_) filled with ROS parameters
+  ublox_msgs::CfgNMEA6 cfg_nmea_; 
+  //! Whether or not to configure the NMEA settings
+  bool set_nmea_; 
 };
 
 /**
- * @brief Abstract class defining functions applicable to Firmware versions >=7.
+ * @brief Abstract class for Firmware versions >= 7.
  * 
- * @details Keeps track of the last NavPVT message uses it to update the fix
- * diagnostics. This class is a template class because the NavPVT message 
+ * @details This class keeps track of the last NavPVT message uses it to 
+ * update the fix diagnostics. It is a template class because the NavPVT message 
  * is a different length for firmware versions 7 and 8.
+ *
+ * @typedef NavPVT the NavPVT message type for the given firmware version
  */
 template<typename NavPVT>
 class UbloxFirmware7Plus : public UbloxFirmware {
@@ -726,85 +766,111 @@ class UbloxFirmware7Plus : public UbloxFirmware {
     stat.add("# SVs used", (int)last_nav_pvt_.numSV);
   }
  
-  NavPVT last_nav_pvt_; //!< The last received NavPVT message
+  //! The last received NavPVT message
+  NavPVT last_nav_pvt_; 
   // Whether or not to enable the given GNSS
-  bool enable_gps_; //!< Whether or not to enable GPS
-  bool enable_glonass_; //!< Whether or not to enable GLONASS
-  bool enable_qzss_; //!< Whether or not to enable QZSS
-  bool enable_sbas_; //!< Whether or not to enable SBAS
-  uint32_t qzss_sig_cfg_;//!< The QZSS Signal configuration, see CfgGNSS message
+  //! Whether or not to enable GPS
+  bool enable_gps_; 
+  //! Whether or not to enable GLONASS
+  bool enable_glonass_; 
+  //! Whether or not to enable QZSS
+  bool enable_qzss_; 
+  //! Whether or not to enable SBAS
+  bool enable_sbas_; 
+  //! The QZSS Signal configuration, see CfgGNSS message
+  uint32_t qzss_sig_cfg_;
 };
 
 /**
- * @brief u-blox functionality for firmware version 7.
+ * @brief  Implements functions for firmware version 7.
  */
 class UbloxFirmware7 : public UbloxFirmware7Plus<ublox_msgs::NavPVT7> {
  public:
   UbloxFirmware7();
 
   /**
-   * @brief Gets the GNSS params.
+   * @brief Get the parameters specific to firmware version 7.
+   *
+   * @details Get the GNSS and NMEA settings.
    */
   void getRosParams();
   
   /**
-   * @brief Configures GNSS individually. Only configures GLONASS.
+   * @brief Configure GNSS individually. Only configures GLONASS.
    */
   bool configureUblox();
   
   /**
-   * @brief Subscribes to messages which are not generic to all firmware. 
+   * @brief Subscribe to messages which are not generic to all firmware. 
    * 
-   * @details Subscribes to NavPVT7 messages, RxmRAW, and RxmSFRB messages. 
+   * @details Subscribe to NavPVT7 messages, RxmRAW, and RxmSFRB messages. 
    */
   void subscribe();
   
   private:
-    ublox_msgs::CfgNMEA7 cfg_nmea_; //!< Used to configure NMEA (if set_nmea_)
-                                    //!< Filled from ROS parameters
-    bool set_nmea_; //!< Whether or not to Configure the NMEA settings
+    //! Used to configure NMEA (if set_nmea_)
+    /*! 
+     * Filled from ROS parameters
+     */
+    ublox_msgs::CfgNMEA7 cfg_nmea_; 
+    //! Whether or not to Configure the NMEA settings
+    bool set_nmea_; 
 };
 
 /**
- *  @brief u-blox functionality for firmware version 8.
+ *  @brief Implements functions for firmware version 8.
  */
 class UbloxFirmware8 : public UbloxFirmware7Plus<ublox_msgs::NavPVT> {
  public:
   UbloxFirmware8();
 
   /**
-   * @brief Gets the GNSS parameters specific to firmware version 8.
+   * @brief Get the ROS parameters specific to firmware version 8.
+   *
+   * @details Get the GNSS, NMEA, and UPD settings.
    */
   void getRosParams();
   
   /**
-   * @brief Configures settings specific to firmware 8 based on ROS params.
+   * @brief Configure settings specific to firmware 8 based on ROS parameters.
    * 
-   * @details Configures GNSS, if it is different from current settings. It also 
-   * configures the NMEA if desired by the user.
+   * @details Configure GNSS, if it is different from current settings.  
+   * Configure the NMEA if desired by the user. It also may clear the 
+   * flash memory based on the ROS parameters.
    */
   bool configureUblox();
   
   /**
-   * @brief Subscribes to messages which are not generic to all firmware. 
+   * @brief Subscribe to u-blox messages which are not generic to all firmware
+   * versions. 
    * 
-   * @details Subscribes to NavPVT, NavSAT, MonHW, and RxmRTCM messages.
+   * @details Subscribe to NavPVT, NavSAT, MonHW, and RxmRTCM messages based
+   * on user settings.
    */
   void subscribe();
 
  private:
-  // Whether or not to enable the given GNSS
-  bool enable_galileo_, enable_beidou_, enable_imes_;
-  uint8_t reset_mode_; //!< Type of device reset after GNSS configuration 
-                       //!< only used if GNSS configuration is changed
-                       //!< see CfgRST message for constants
-  bool set_nmea_; //!< Whether or not to configure the NMEA settings
-  ublox_msgs::CfgNMEA cfg_nmea_; //!< Desired NMEA configuration
-                                 //!< set from ROS parameters
-  bool save_on_shutdown_; //!< If true, node will send command to saves the BBR 
-                          //!< shutdown to flash memory on  
-  bool clear_bbr_; //!< If true, node will send command to clear the flash 
-                   //!< memory during config
+  // Set from ROS parameters
+  //! Whether or not to enable the Galileo GNSS
+  bool enable_galileo_; 
+  //! Whether or not to enable the BeiDuo GNSS
+  bool enable_beidou_; 
+  //! Whether or not to enable the IMES GNSS
+  bool enable_imes_; 
+  //! Type of device reset after GNSS configuration. 
+  /*!
+   * Only used if GNSS configuration is changed.
+   * See CfgRST message for constants.
+   */
+  uint8_t reset_mode_;
+  //! Whether or not to configure the NMEA settings
+  bool set_nmea_; 
+  //! Desired NMEA configuration.
+  ublox_msgs::CfgNMEA cfg_nmea_; 
+  //! Whether to save the BBR to flash on shutdown
+  bool save_on_shutdown_; 
+  //! Whether to clear the flash memory during configuration
+  bool clear_bbr_; 
 };
 
 /**
@@ -814,25 +880,29 @@ class UbloxFirmware8 : public UbloxFirmware7Plus<ublox_msgs::NavPVT> {
 class UbloxAdrUdr: public virtual ComponentInterface {
  public:
   /**
-   * @brief Gets the ADR/UDR parameters, such as use_adr.
+   * @brief Get the ADR/UDR parameters.
+   *
+   * @details Get the use_adr parameter and check that the nav_rate is 1 Hz.
    */
   void getRosParams();
 
   /**
-   * @brief Configures ADR/UDR settings, such as use_adr.
-   * @returns true if configured correctly, false otherwise
+   * @brief Configure ADR/UDR settings.
+   * @details Configure the use_adr setting.
+   * @return true if configured correctly, false otherwise
    */
   bool configureUblox();
 
   /**
-   * @brief Subscribes to ADR/UDR messages.
+   * @brief Subscribe to ADR/UDR messages.
    *
-   * @details Subscribes to NavATT, ESF and HNR messages
+   * @details Subscribe to NavATT, ESF and HNR messages based on user 
+   * parameters.
    */
   void subscribe();
 
   /**
-   * @brief Initializes the ROS diagnostics for the ADR/UDR device.
+   * @brief Initialize the ROS diagnostics for the ADR/UDR device.
    * @todo unimplemented
    */
   void initializeRosDiagnostics() {
@@ -841,7 +911,8 @@ class UbloxAdrUdr: public virtual ComponentInterface {
   }
 
  protected:
-  bool use_adr_; //!< Whether or not to enable dead reckoning
+  //! Whether or not to enable dead reckoning
+  bool use_adr_; 
 };
 
 /**
@@ -850,7 +921,8 @@ class UbloxAdrUdr: public virtual ComponentInterface {
  */
 class UbloxFts: public virtual ComponentInterface {
   /**
-   * @brief Gets the FTS parameters. Currently unimplemented.
+   * @brief Get the FTS parameters. 
+   * @todo Currently unimplemented.
    */
   void getRosParams() {
     ROS_WARN("Functionality specific to U-Blox FTS devices is %s",
@@ -858,17 +930,20 @@ class UbloxFts: public virtual ComponentInterface {
   }
 
   /**
-   * @brief Configures FTS settings. Currently unimplemented.
+   * @brief Configure FTS settings. 
+   * @todo Currently unimplemented.
    */
   bool configureUblox() {}
 
   /**
-   * @brief Subscribes to FTS GNSS messages.
+   * @brief Subscribe to FTS messages.
+   * @todo Currently unimplemented.
    */
   void subscribe() {}
 
   /**
    * @brief Adds diagnostic updaters for FTS status. 
+   * @todo Currently unimplemented.
    */
   void initializeRosDiagnostics() {}
 };
@@ -880,29 +955,40 @@ class UbloxFts: public virtual ComponentInterface {
 class UbloxHpgRef: public virtual ComponentInterface {
  public:
   /**
-   * @brief Gets the Reference Station GNSS parameters, such as tmode3.
+   * @brief Get the ROS parameters specific to the Reference Station 
+   * configuration.
+   *
+   * @details Get the TMODE3 settings, the parameters it gets depends on the 
+   * tmode3 parameter. For example, it will get survey-in parameters if the 
+   * tmode3 parameter is set to survey in or it will get the fixed parameters if
+   * it is set to fixed.
    */
   void getRosParams();
 
   /**
-   * @brief Configures Reference Station settings, such as TMODE3.
-   * @returns true if configured correctly, false otherwise
+   * @brief Configure the u-blox Reference Station settings.
+   *
+   * @details Configure the TMODE3 settings and sets the internal state based
+   * on the TMODE3 status. If the TMODE3 is set to fixed, it will configure
+   * the RTCM messages.
+   * @return true if configured correctly, false otherwise
    */
   bool configureUblox();
 
   /**
-   * @brief Subscribes to u-blox Reference Station messages, such as NavSVIN.
+   * @brief Subscribe to u-blox Reference Station messages.
+   *
+   * @details Subscribe to NavSVIN messages based on user parameters.
    */
   void subscribe();
 
   /**
-   * @brief Adds diagnostic updaters for Reference Station status, including
-   * TMODE status.
+   * @brief Add diagnostic updaters for the TMODE3 status.
    */
   void initializeRosDiagnostics();
 
   /**
-   * @brief Publishes received Nav SVIN messages. 
+   * @brief Publish received Nav SVIN messages and updates diagnostics. 
    *
    * @details When the survey in finishes, it changes the measurement & 
    * navigation rate to the user configured values and enables the user 
@@ -927,27 +1013,49 @@ class UbloxHpgRef: public virtual ComponentInterface {
    */
   bool setTimeMode();
 
-  ublox_msgs::NavSVIN last_nav_svin_; //!< The last received Nav SVIN message
+  //! The last received Nav SVIN message
+  ublox_msgs::NavSVIN last_nav_svin_; 
 
-  uint8_t tmode3_; //!< TMODE3 to set, such as disabled, survey-in, fixed
+  //! TMODE3 to set, such as disabled, survey-in, fixed
+  uint8_t tmode3_; 
   
-  bool lla_flag_; //!< TMODE3 = Fixed mode settings
-  //!< True if coordinates are in LLA, false if ECEF
-  std::vector<float> arp_position_; //!< Antenna Reference Point Position [m]
-                                   //!< or [deg]
-  std::vector<int8_t> arp_position_hp_; //!< Antenna Reference Point Position 
-                                        //!< High Precision [0.1 mm] or 
-                                        //!< [deg * 1e-9]
-  float fixed_pos_acc_; //!< Fixed Position Accuracy [m]
+  // TMODE3 = Fixed mode settings
+  //! True if coordinates are in LLA, false if ECEF
+  /*! Used only for fixed mode */
+  bool lla_flag_; 
+  //! Antenna Reference Point Position [m] or [deg]
+  /*! Used only for fixed mode */
+  std::vector<float> arp_position_; 
+  //! Antenna Reference Point Position High Precision [0.1 mm] or [deg * 1e-9]
+  /*! Used only for fixed mode */
+  std::vector<int8_t> arp_position_hp_; 
+  //! Fixed Position Accuracy [m]
+  /*! Used only for fixed mode */
+  float fixed_pos_acc_; 
   
   // Settings for TMODE3 = Survey-in
-  bool svin_reset_; //!< If true, the node resets the survey-in during 
-                    //!< configuration. If false, it only resets if
-                    //!< there's no fix and TMODE3 is disabled
-  uint32_t sv_in_min_dur_; //!< Measurement period used during Survey-In [s]
-  float sv_in_acc_lim_; //!< Survey in accuracy limit [m]
+  //! Whether to always reset the survey-in during configuration.
+  /*! 
+   * If false, it only resets survey-in if there's no fix and TMODE3 is 
+   * disabled before configuration.
+   * This variable is used only if TMODE3 is set to survey-in.
+   */
+  bool svin_reset_; 
+  //! Measurement period used during Survey-In [s]
+  /*! This variable is used only if TMODE3 is set to survey-in. */
+  uint32_t sv_in_min_dur_; 
+  //! Survey in accuracy limit [m]
+  /*! This variable is used only if TMODE3 is set to survey-in. */
+  float sv_in_acc_lim_; 
 
-  enum {INIT, FIXED, DISABLED, SURVEY_IN, TIME} mode_;  //!< Current device mode
+  //! Status of device time mode
+  enum {
+    INIT, //!< Initialization mode (before configuration)
+    FIXED, //!< Fixed mode (should switch to time mode almost immediately)
+    DISABLED, //!< Time mode disabled
+    SURVEY_IN, //!< Survey-In mode
+    TIME //!< Time mode, after survey-in or after configuring fixed mode
+  } mode_;  
 };
 
 /**
@@ -956,33 +1064,36 @@ class UbloxHpgRef: public virtual ComponentInterface {
 class UbloxHpgRov: public virtual ComponentInterface {
  public:
   // Constants for diagnostic updater
-  const static double kRtcmFreqMin = 1; //!< Diagnostic updater: RTCM topic 
-                                        //!< frequency min [Hz]
-  const static double kRtcmFreqMax = 10; //!< Diagnostic updater: RTCM topic 
-                                         //!< frequency max [Hz]
-  const static double kRtcmFreqTol = 0.1; //!< Diagnostic updater: RTCM topic 
-                                          //!< frequency tolerance[%]
-  const static int kRtcmFreqWindow = 25; //!< Diagnostic updater: RTCM topic 
-                                         //!< frequency window [num messages]
+  //! Diagnostic updater: RTCM topic frequency min [Hz]
+  const static double kRtcmFreqMin = 1; 
+  //! Diagnostic updater: RTCM topic frequency max [Hz]
+  const static double kRtcmFreqMax = 10; 
+  //! Diagnostic updater: RTCM topic frequency tolerance [%]
+  const static double kRtcmFreqTol = 0.1;
+  //! Diagnostic updater: RTCM topic frequency window [num messages]
+  const static int kRtcmFreqWindow = 25; 
   /**
-   * @brief Gets the High Precision GNSS rover parameters.
-   * @details Gets the DGNSS mode.
+   * @brief Get the ROS parameters specific to the Rover configuration.
+   *
+   * @details Get the DGNSS mode.
    */
   void getRosParams();
 
   /**
-   * @brief Configures rover settings, including DGNSS.
-   * @returns true if configured correctly, false otherwise
+   * @brief Configure rover settings.
+   *
+   * @details Configure the DGNSS mode.
+   * @return true if configured correctly, false otherwise
    */
   bool configureUblox();
 
   /**
-   * @brief Subscribes to Rover messages, such as NavRELPOSNED.
+   * @brief Subscribe to Rover messages, such as NavRELPOSNED.
    */
   void subscribe();
 
   /**
-   * @brief Adds diagnostic updaters for rover GNSS status, including
+   * @brief Add diagnostic updaters for rover GNSS status, including
    * status of RTCM messages.
    */
   void initializeRosDiagnostics();
@@ -1003,16 +1114,20 @@ class UbloxHpgRov: public virtual ComponentInterface {
   void publishNavRelPosNed(const ublox_msgs::NavRELPOSNED &m);
 
 
-  ublox_msgs::NavRELPOSNED last_rel_pos_; //!< Last relative position
-                                          //!< used for diagnostic updater
+  //! Last relative position (used for diagnostic updater)
+  ublox_msgs::NavRELPOSNED last_rel_pos_; 
 
   // For RTCM frequency diagnostic updater
-  double rtcm_freq_min; //!< Diagnostic: RTCM frequency min (set from constant)
-  double rtcm_freq_max; //!< Diagnostic: RTCM frequency max (set from constant)
+  //! Diagnostic: RTCM frequency min (set from constant)
+  double rtcm_freq_min; 
+  //! Diagnostic: RTCM frequency max (set from constant)
+  double rtcm_freq_max; 
 
-  uint8_t dgnss_mode_; //!< The DGNSS mode
-                       //!< see CfgDGNSS message for possible values
+  //! The DGNSS mode
+  /*! see CfgDGNSS message for possible values */
+  uint8_t dgnss_mode_; 
 
+  // The RTCM topic frequency diagnostic updater
   boost::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> freq_rtcm_;
 };
 
@@ -1022,7 +1137,7 @@ class UbloxHpgRov: public virtual ComponentInterface {
  */
 class UbloxTim: public virtual ComponentInterface {
   /**
-   * @brief Gets the Time Sync parameters. 
+   * @brief Get the Time Sync parameters. 
    * @todo Currently unimplemented.
    */
   void getRosParams() {
@@ -1031,13 +1146,15 @@ class UbloxTim: public virtual ComponentInterface {
   }
 
   /**
-   * @brief Configures Time Sync settings.
+   * @brief Configure Time Sync settings.
    * @todo Currently unimplemented.
    */
   bool configureUblox() {}
 
   /**
-   * @brief Subscribes to Time Sync GNSS messages: currently RxmRAWX & RxmSFRBX.
+   * @brief Subscribe to Time Sync messages.
+   *
+   * @details Subscribes to RxmRAWX & RxmSFRBX messages.
    */
   void subscribe();
 

--- a/ublox_gps/include/ublox_gps/utils.h
+++ b/ublox_gps/include/ublox_gps/utils.h
@@ -9,7 +9,9 @@ extern "C" {
   #include "ublox_gps/mkgmtime.h"
 }
 
-// Convert date/time to UTC time in seconds
+/**
+ * @brief Convert date/time to UTC time in seconds.
+ */
 template<typename NavPVT>
 long toUtcSeconds(const NavPVT& msg) {
   // Create TM struct for mkgmtime

--- a/ublox_gps/include/ublox_gps/worker.h
+++ b/ublox_gps/include/ublox_gps/worker.h
@@ -34,16 +34,36 @@
 
 namespace ublox_gps {
 
+/**
+ * @brief Handles I/O reading and writing.
+ */
 class Worker {
  public:
   typedef boost::function<void(unsigned char*, std::size_t&)> Callback;
   virtual ~Worker() {}
 
+  /**
+   * @brief Set the callback function for received messages.
+   * @param callback the callback function which process messages in the buffer
+   */
   virtual void setCallback(const Callback& callback) = 0;
 
+  /**
+   * @brief Send the data in the buffer.
+   * @param data the bytes to send
+   * @param size the size of the buffer
+   */
   virtual bool send(const unsigned char* data, const unsigned int size) = 0;
+  
+  /**
+   * @brief Wait for an incoming message.
+   * @param timeout the maximum time to wait.
+   */
   virtual void wait(const boost::posix_time::time_duration& timeout) = 0;
 
+  /**
+   * @brief Whether or not the I/O stream is open.
+   */
   virtual bool isOpen() const = 0;
 };
 

--- a/ublox_gps/launch/ublox_device.launch
+++ b/ublox_gps/launch/ublox_device.launch
@@ -6,9 +6,11 @@
   <arg name="output" default="screen" />
   <arg name="respawn" default="true" />
   <arg name="respawn_delay" default="30" />
+  <arg name="clear_params" default="true" />
 
   <node pkg="ublox_gps" type="ublox_gps" name="$(arg node_name)"
         output="$(arg output)" 
+        clear_params="$(arg clear_params)"
         respawn="$(arg respawn)" 
         respawn_delay="$(arg respawn_delay)">
     <rosparam command="load" 

--- a/ublox_gps/launch/ublox_device.launch
+++ b/ublox_gps/launch/ublox_device.launch
@@ -4,9 +4,13 @@
   <arg name="node_name" />
   <arg name="param_file_name" doc="name of param file, e.g. rover" />
   <arg name="output" default="screen" />
+  <arg name="respawn" default="true" />
+  <arg name="respawn_delay" default="30" />
 
   <node pkg="ublox_gps" type="ublox_gps" name="$(arg node_name)"
-        output="$(arg output)">
+        output="$(arg output)" 
+        respawn="$(arg respawn)" 
+        respawn_delay="$(arg respawn_delay)">
     <rosparam command="load" 
               file="$(find ublox_gps)/config/$(arg param_file_name).yaml" />
   </node>

--- a/ublox_gps/package.xml
+++ b/ublox_gps/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package format='2'>
   <name>ublox_gps</name>
-  <version>1.1.0</version>
+  <version>1.1.2</version>
   <description>
-     Driver for ublox GPS devices.
+     Driver for u-blox GPS devices.
   </description>
   <author>Johannes Meyer</author>
   <maintainer email="gcross.code@icloud.com">Gareth Cross</maintainer>

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -435,14 +435,7 @@ void Gps::readCallback(unsigned char* data, std::size_t& size) {
                oss.str().c_str());
     }
 
-    // Find the callback handlers for the message & decode it
-    callback_mutex_.lock();
-    Callbacks::key_type key =
-        std::make_pair(reader.classId(), reader.messageId());
-    for (Callbacks::iterator callback = callbacks_.lower_bound(key);
-         callback != callbacks_.upper_bound(key); ++callback)
-      callback->second->handle(reader);
-    callback_mutex_.unlock();
+    callbacks_.handle(reader);
 
     if (reader.classId() == ublox_msgs::Class::ACK) {
       // Process ACK/NACK messages

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -269,6 +269,22 @@ bool Gps::disableUart1(CfgPRT& prev_config) {
   return configure(port);
 }
 
+bool Gps::configUsb(uint16_t tx_ready,
+                    uint16_t in_proto_mask, 
+                    uint16_t out_proto_mask) {
+  if (!worker_) return true;
+
+  ROS_DEBUG("Configuring USB tx_ready: %u, In/Out Protocol: %u / %u", 
+            tx_ready, in_proto_mask, out_proto_mask);
+
+  CfgPRT port;
+  port.portID = CfgPRT::PORT_ID_USB;
+  port.txReady = tx_ready;
+  port.inProtoMask = in_proto_mask;
+  port.outProtoMask = out_proto_mask;
+  return configure(port);
+}
+
 bool Gps::configRate(uint16_t meas_rate, uint16_t nav_rate) {
   ROS_DEBUG("Configuring measurement rate to %u and nav rate to %u", meas_rate, 
            nav_rate);

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -320,7 +320,7 @@ bool Gps::configSbas(bool enable, uint8_t usage, uint8_t max_sbas) {
 
 bool Gps::configTmode3Fixed(bool lla_flag,
                             std::vector<float> arp_position, 
-                            std::vector<float> arp_position_hp,
+                            std::vector<int8_t> arp_position_hp,
                             float fixed_pos_acc) {
   if(arp_position.size() != 3 || arp_position_hp.size() != 3) {
     ROS_ERROR("Configuring TMODE3 to Fixed: size of position %s",
@@ -336,24 +336,21 @@ bool Gps::configTmode3Fixed(bool lla_flag,
 
   // Set position
   if(lla_flag) {
-    // Convert from deg to deg / 1e-7
+    // Convert from [deg] to [deg * 1e-7]
     tmode3.ecefXOrLat = (int)round(arp_position[0] * 1e7);
     tmode3.ecefYOrLon = (int)round(arp_position[1] * 1e7);
     tmode3.ecefZOrAlt = (int)round(arp_position[2] * 1e7);
-    tmode3.ecefXOrLatHP = (int)round(arp_position_hp[0] * 1e7);
-    tmode3.ecefYOrLonHP = (int)round(arp_position_hp[1] * 1e7);
-    tmode3.ecefZOrAltHP = (int)round(arp_position_hp[2] * 1e7);
   } else {
     // Convert from m to cm
     tmode3.ecefXOrLat = (int)round(arp_position[0] * 1e2);
     tmode3.ecefYOrLon = (int)round(arp_position[1] * 1e2);
     tmode3.ecefZOrAlt = (int)round(arp_position[2] * 1e2);
-    tmode3.ecefXOrLatHP = (int)round(arp_position_hp[0] * 1e2);
-    tmode3.ecefYOrLonHP = (int)round(arp_position_hp[1] * 1e2);
-    tmode3.ecefZOrAltHP = (int)round(arp_position_hp[2] * 1e2);
   }
+  tmode3.ecefXOrLatHP = arp_position_hp[0];
+  tmode3.ecefYOrLonHP = arp_position_hp[1];
+  tmode3.ecefZOrAltHP = arp_position_hp[2];
   // Convert from m to [0.1 mm]
-  tmode3.fixedPosAcc = (int)round(fixed_pos_acc * 1e4);
+  tmode3.fixedPosAcc = (uint32_t)round(fixed_pos_acc * 1e4);
   return configure(tmode3);
 }
 

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -122,26 +122,26 @@ void UbloxNode::getRosParams() {
   nh->param("device", device_, std::string("/dev/ttyACM0"));
   nh->param("frame_id", frame_id, std::string("gps"));
   // UART 1 params
-  getRosParam("uart1/baudrate", baudrate_, 9600);
-  getRosParam("uart1/in", uart_in_, ublox_msgs::CfgPRT::PROTO_UBX 
+  getRosUint("uart1/baudrate", baudrate_, 9600);
+  getRosUint("uart1/in", uart_in_, ublox_msgs::CfgPRT::PROTO_UBX 
                                     | ublox_msgs::CfgPRT::PROTO_NMEA
                                     | ublox_msgs::CfgPRT::PROTO_RTCM);
-  getRosParam("uart1/out", uart_out_, ublox_msgs::CfgPRT::PROTO_UBX);
+  getRosUint("uart1/out", uart_out_, ublox_msgs::CfgPRT::PROTO_UBX);
   // Measurement rate params
   nh->param("rate", rate_, 4.0);  // in Hz
-  getRosParam("nav_rate", nav_rate, 1);  // # of measurement rate cycles
+  getRosUint("nav_rate", nav_rate, 1);  // # of measurement rate cycles
   // RTCM params
-  getRosParam("rtcm/ids", rtcm_ids);  // RTCM output message IDs 
-  getRosParam("rtcm/rates", rtcm_rates);  // RTCM output message rates
+  getRosUint("rtcm/ids", rtcm_ids);  // RTCM output message IDs 
+  getRosUint("rtcm/rates", rtcm_rates);  // RTCM output message rates
   // PPP: Advanced Setting
   nh->param("enable_ppp", enable_ppp_, false);
   // SBAS params, only for some devices
   nh->param("sbas", enable_sbas_, false);
-  getRosParam("sbas/max", max_sbas_, 0); // Maximum number of SBAS channels
-  getRosParam("sbas/usage", sbas_usage_, 0);
+  getRosUint("sbas/max", max_sbas_, 0); // Maximum number of SBAS channels
+  getRosUint("sbas/usage", sbas_usage_, 0);
   nh->param("dynamic_model", dynamic_model_, std::string("portable"));
   nh->param("fix_mode", fix_mode_, std::string("auto"));
-  getRosParam("dr_limit", dr_limit_, 0); // Dead reckoning limit
+  getRosUint("dr_limit", dr_limit_, 0); // Dead reckoning limit
 
   if (enable_ppp_) 
     ROS_WARN("Warning: PPP is enabled - this is an expert setting.");
@@ -523,10 +523,10 @@ void UbloxFirmware6::getRosParams() {
   if (set_nmea_) {
     bool compat, consider;
 
-    if (!getRosParam("nmea/version", cfg_nmea_.version))
+    if (!getRosUint("nmea/version", cfg_nmea_.version))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
           "true, therefore nmea/version must be set");
-    if (!getRosParam("nmea/num_sv", cfg_nmea_.numSV))
+    if (!getRosUint("nmea/num_sv", cfg_nmea_.numSV))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
                 "true, therefore nmea/num_sv must be set");
     if (!nh->getParam("nmea/compat", compat))
@@ -754,7 +754,7 @@ void UbloxFirmware7::getRosParams() {
   nh->param("gnss/gps", enable_gps_, true);
   nh->param("gnss/glonass", enable_glonass_, false);
   nh->param("gnss/qzss", enable_qzss_, false);
-  getRosParam("gnss/qzss_sig_cfg", qzss_sig_cfg_, 
+  getRosUint("gnss/qzss_sig_cfg", qzss_sig_cfg_, 
               ublox_msgs::CfgGNSS_Block::SIG_CFG_QZSS_L1CA);
   nh->param("gnss/sbas", enable_sbas_, false);
   
@@ -790,13 +790,13 @@ void UbloxFirmware7::getRosParams() {
   if (set_nmea_) {
     bool compat, consider;
 
-    if (!getRosParam("nmea/version", cfg_nmea_.nmeaVersion))
+    if (!getRosUint("nmea/version", cfg_nmea_.nmeaVersion))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
           "true, therefore nmea/version must be set");
-    if (!getRosParam("nmea/num_sv", cfg_nmea_.numSV))
+    if (!getRosUint("nmea/num_sv", cfg_nmea_.numSV))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
                 "true, therefore nmea/num_sv must be set");
-    if (!getRosParam("nmea/sv_numbering", cfg_nmea_.svNumbering))
+    if (!getRosUint("nmea/sv_numbering", cfg_nmea_.svNumbering))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
           "true, therefore nmea/sv_numbering must be set");
     if (!nh->getParam("nmea/compat", compat))
@@ -833,8 +833,8 @@ void UbloxFirmware7::getRosParams() {
     nh->param("nmea/gnssToFilter/glonass", temp, false);
     cfg_nmea_.gnssToFilter |= temp ? cfg_nmea_.GNSS_TO_FILTER_GLONASS : 0;
 
-    getRosParam("nmea/main_talker_id", cfg_nmea_.mainTalkerId);
-    getRosParam("nmea/gsv_talker_id", cfg_nmea_.gsvTalkerId);
+    getRosUint("nmea/main_talker_id", cfg_nmea_.mainTalkerId);
+    getRosUint("nmea/gsv_talker_id", cfg_nmea_.gsvTalkerId);
   } 
 }
 
@@ -973,11 +973,11 @@ void UbloxFirmware8::getRosParams() {
   nh->param("gnss/qzss", enable_qzss_, false);
   nh->param("gnss/sbas", enable_sbas_, false);
   // QZSS Signal Configuration
-  getRosParam("gnss/qzss_sig_cfg", qzss_sig_cfg_, 
+  getRosUint("gnss/qzss_sig_cfg", qzss_sig_cfg_, 
               ublox_msgs::CfgGNSS_Block::SIG_CFG_QZSS_L1CA);
   // Reset type, device is only reset if GNSS configuration is changed
   reset_mode_ = ublox_msgs::CfgRST::RESET_MODE_GNSS; // default
-  getRosParam("gnss/reset_mode", reset_mode_, reset_mode_);
+  getRosUint("gnss/reset_mode", reset_mode_, reset_mode_);
 
   if (enable_gps_ && !supportsGnss("GPS")) 
     ROS_WARN("gnss/gps is true, but GPS GNSS is not supported by %s",
@@ -1014,13 +1014,13 @@ void UbloxFirmware8::getRosParams() {
     cfg_nmea_.version = cfg_nmea_.VERSION; // message version
 
     // Verify that parameters are set
-    if (!getRosParam("nmea/version", cfg_nmea_.nmeaVersion))
+    if (!getRosUint("nmea/version", cfg_nmea_.nmeaVersion))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
           "true, therefore nmea/version must be set");
-    if (!getRosParam("nmea/num_sv", cfg_nmea_.numSV))
+    if (!getRosUint("nmea/num_sv", cfg_nmea_.numSV))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
                 "true, therefore nmea/num_sv must be set");
-    if (!getRosParam("nmea/sv_numbering", cfg_nmea_.svNumbering))
+    if (!getRosUint("nmea/sv_numbering", cfg_nmea_.svNumbering))
       throw std::runtime_error(std::string("Invalid settings: nmea/set is ") +
           "true, therefore nmea/sv_numbering must be set");
     if (!nh->getParam("nmea/compat", compat))
@@ -1063,11 +1063,11 @@ void UbloxFirmware8::getRosParams() {
     nh->param("nmea/gnssToFilter/beidou", temp, false);
     cfg_nmea_.gnssToFilter |= temp ? cfg_nmea_.GNSS_TO_FILTER_BEIDOU : 0;
 
-    getRosParam("nmea/main_talker_id", cfg_nmea_.mainTalkerId);
-    getRosParam("nmea/gsv_talker_id", cfg_nmea_.gsvTalkerId);
+    getRosUint("nmea/main_talker_id", cfg_nmea_.mainTalkerId);
+    getRosUint("nmea/gsv_talker_id", cfg_nmea_.gsvTalkerId);
     
     std::vector<uint8_t> bdsTalkerId;
-    getRosParam("nmea/bds_talker_id", bdsTalkerId);
+    getRosUint("nmea/bds_talker_id", bdsTalkerId);
     cfg_nmea_.bdsTalkerId[0] = bdsTalkerId[0];
     cfg_nmea_.bdsTalkerId[1] = bdsTalkerId[1];
   } 
@@ -1259,14 +1259,14 @@ void UbloxHpgRef::getRosParams() {
   if(nav_rate * meas_rate != 1000)
     ROS_WARN("For HPG Ref devices, nav_rate should be exactly 1 Hz.");
 
-  if(!getRosParam("tmode3", tmode3_))
+  if(!getRosUint("tmode3", tmode3_))
     throw std::runtime_error("Invalid settings: TMODE3 must be set");
 
   if(tmode3_ == ublox_msgs::CfgTMODE3::FLAGS_MODE_FIXED) {
     if(!nh->getParam("arp/position", arp_position_))
       throw std::runtime_error(std::string("Invalid settings: arp/position ") 
                                + "must be set if TMODE3 is fixed");
-    if(!nh->getParam("arp/position_hp", arp_position_hp_))
+    if(!getRosInt("arp/position_hp", arp_position_hp_))
       throw std::runtime_error(std::string("Invalid settings: arp/position_hp ") 
                                + "must be set if TMODE3 is fixed");
     if(!nh->getParam("arp/acc", fixed_pos_acc_))
@@ -1279,7 +1279,7 @@ void UbloxHpgRef::getRosParams() {
     }
   } else if(tmode3_ == ublox_msgs::CfgTMODE3::FLAGS_MODE_SURVEY_IN) {
     nh->param("sv_in/reset", svin_reset_, true);
-    if(!getRosParam("sv_in/min_dur", sv_in_min_dur_))
+    if(!getRosUint("sv_in/min_dur", sv_in_min_dur_))
       throw std::runtime_error(std::string("Invalid settings: sv_in/min_dur ") 
                                + "must be set if TMODE3 is survey-in");
     if(!nh->getParam("sv_in/acc_lim", sv_in_acc_lim_))
@@ -1445,7 +1445,7 @@ void UbloxHpgRef::tmode3Diagnostics(
 //
 void UbloxHpgRov::getRosParams() {
   // default to float, see CfgDGNSS message for details
-  getRosParam("dgnss_mode", dgnss_mode_, 
+  getRosUint("dgnss_mode", dgnss_mode_, 
               ublox_msgs::CfgDGNSS::DGNSS_MODE_RTK_FIXED); 
 }
 

--- a/ublox_msgs/include/ublox/serialization/ublox_msgs.h
+++ b/ublox_msgs/include/ublox/serialization/ublox_msgs.h
@@ -34,13 +34,22 @@
 #include <ublox/serialization.h>
 #include <ublox_msgs/ublox_msgs.h>
 
+/// This file declares custom serializers for u-blox messages with dynamic 
+/// lengths and messages where the get/set messages have different sizes, but
+/// share the same parameters, such as CfgDAT.
+
 namespace ublox {
 
+///
+/// @brief Serializes the CfgDAT message which has a different length for 
+/// get/set.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::CfgDAT_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::CfgDAT_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::CfgDAT_<ContainerAllocator> > {
+  typedef boost::call_traits<ublox_msgs::CfgDAT_<ContainerAllocator> > 
+      CallTraits;
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.datumNum);
     stream.next(m.datumName);
@@ -55,15 +64,14 @@ struct Serializer<ublox_msgs::CfgDAT_<ContainerAllocator> >
     stream.next(m.scale);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::CfgDAT_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     // this is the size of CfgDAT set messages
     // serializedLength is only used for writes so this is ok
     return 44;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::CfgDAT_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     // ignores datumNum & datumName
     stream.next(m.majA);
@@ -78,11 +86,16 @@ struct Serializer<ublox_msgs::CfgDAT_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the CfgGNSS message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::CfgGNSS_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::CfgGNSS_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::CfgGNSS_<ContainerAllocator> > {
+  typedef ublox_msgs::CfgGNSS_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.msgVer);
     stream.next(m.numTrkChHw);
@@ -93,13 +106,12 @@ struct Serializer<ublox_msgs::CfgGNSS_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.blocks[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::CfgGNSS_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 4 + 8 * m.numConfigBlocks;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::CfgGNSS_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.blocks.size() != m.numConfigBlocks) {
       ROS_ERROR("CfgGNSS numConfigBlocks must equal blocks size");
     }
@@ -107,17 +119,23 @@ struct Serializer<ublox_msgs::CfgGNSS_<ContainerAllocator> >
     stream.next(m.msgVer);
     stream.next(m.numTrkChHw);
     stream.next(m.numTrkChUse);
-    stream.next(static_cast<typename ublox_msgs::CfgGNSS_<ContainerAllocator>::_numConfigBlocks_type>(m.blocks.size()));
+    stream.next(
+        static_cast<typename Msg::_numConfigBlocks_type>(m.blocks.size()));
     for(std::size_t i = 0; i < m.blocks.size(); ++i) 
       ros::serialization::serialize(stream, m.blocks[i]);
   }
 };
 
+///
+/// @brief Serializes the CfgInf message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::CfgINF_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::CfgINF_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::CfgINF_<ContainerAllocator> > {
+  typedef boost::call_traits<ublox_msgs::CfgINF_<ContainerAllocator> > 
+      CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count,
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     int num_blocks = count / 10;
     m.blocks.resize(num_blocks);
@@ -125,75 +143,76 @@ struct Serializer<ublox_msgs::CfgINF_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.blocks[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::CfgINF_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 10 * m.blocks.size();
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::CfgINF_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     for(std::size_t i = 0; i < m.blocks.size(); ++i) 
       ros::serialization::serialize(stream, m.blocks[i]);
   }
 };
 
+///
+/// @brief Serializes the Inf message which has a dynamic length string.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::Inf_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::Inf_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::Inf_<ContainerAllocator> > {
+  typedef boost::call_traits<ublox_msgs::Inf_<ContainerAllocator> > CallTraits;
+  
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     m.str.resize(count);
     for (int i = 0; i < count; ++i)
       ros::serialization::deserialize(stream, m.str[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::Inf_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return m.str.size();
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::Inf_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     for(std::size_t i = 0; i < m.str.size(); ++i) 
       ros::serialization::serialize(stream, m.str[i]);
   }
 };
 
+///
+/// @brief Serializes the MonVER message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::MonVER_<ContainerAllocator> >
-{
+struct Serializer<ublox_msgs::MonVER_<ContainerAllocator> > {
+  typedef ublox_msgs::MonVER_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
   static void read(const uint8_t *data, uint32_t count, 
-      typename boost::call_traits<ublox_msgs::MonVER_<ContainerAllocator> >::reference m)
-  {
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.swVersion);
     stream.next(m.hwVersion);
 
     m.extension.clear();
-    try {
-      typename ublox_msgs::MonVER_<ContainerAllocator>::_extension_type::value_type temp;
-      while(true) {
-        // Read each extension string, will throw exception when end is reached
-        stream.next(temp);
-        m.extension.push_back(temp);
-      }
-    } catch(ros::serialization::StreamOverrunException& e) {
-      // This is expected once the end of the extension array is reached
+    int N = (count - 40) / 30;
+    m.extension.reserve(N);
+    typename Msg::_extension_type::value_type ext;
+    for (int i = 0; i < N; i++) {
+      // Read each extension string
+      stream.next(ext);
+      m.extension.push_back(ext);
     }
   }
 
-  static uint32_t serializedLength(
-      typename boost::call_traits<ublox_msgs::MonVER_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength(typename CallTraits::param_type m) {
     return 40 + (30 * m.extension.size());
   }
 
   static void write(uint8_t *data, uint32_t size, 
-      typename boost::call_traits<ublox_msgs::MonVER_<ContainerAllocator> >::param_type m)
-  {
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     stream.next(m.swVersion);
     stream.next(m.hwVersion);
@@ -202,11 +221,16 @@ struct Serializer<ublox_msgs::MonVER_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the NavDGPS message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::NavDGPS_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::NavDGPS_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::NavDGPS_<ContainerAllocator> > {
+  typedef ublox_msgs::NavDGPS_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.iTOW);
     stream.next(m.age);
@@ -220,13 +244,12 @@ struct Serializer<ublox_msgs::NavDGPS_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.sv[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::NavDGPS_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 16 + 12 * m.numCh;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::NavDGPS_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.sv.size() != m.numCh) {
       ROS_ERROR("NavDGPS numCh must equal sv size");
     }
@@ -235,7 +258,7 @@ struct Serializer<ublox_msgs::NavDGPS_<ContainerAllocator> >
     stream.next(m.age);
     stream.next(m.baseId);
     stream.next(m.baseHealth);
-    stream.next(static_cast<typename ublox_msgs::NavDGPS_<ContainerAllocator>::_numCh_type>(m.sv.size()));
+    stream.next(static_cast<typename Msg::_numCh_type>(m.sv.size()));
     stream.next(m.status);
     stream.next(m.reserved1);
     for(std::size_t i = 0; i < m.sv.size(); ++i) 
@@ -243,11 +266,17 @@ struct Serializer<ublox_msgs::NavDGPS_<ContainerAllocator> >
   }
 };
 
+
+///
+/// @brief Serializes the NavSBAS message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::NavSBAS_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::NavSBAS_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::NavSBAS_<ContainerAllocator> > {
+  typedef ublox_msgs::NavSBAS_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.iTOW);
     stream.next(m.geo);
@@ -261,13 +290,12 @@ struct Serializer<ublox_msgs::NavSBAS_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.sv[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::NavSBAS_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 12 + 12 * m.cnt;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::NavSBAS_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.sv.size() != m.cnt) {
       ROS_ERROR("NavSBAS cnt must equal sv size");
     }
@@ -277,18 +305,23 @@ struct Serializer<ublox_msgs::NavSBAS_<ContainerAllocator> >
     stream.next(m.mode);
     stream.next(m.sys);
     stream.next(m.service);
-    stream.next(static_cast<typename ublox_msgs::NavSBAS_<ContainerAllocator>::_cnt_type>(m.sv.size()));
+    stream.next(static_cast<typename Msg::_cnt_type>(m.sv.size()));
     stream.next(m.reserved0);
     for(std::size_t i = 0; i < m.sv.size(); ++i) 
       ros::serialization::serialize(stream, m.sv[i]);
   }
 };
 
+///
+/// @brief Serializes the NavSAT message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::NavSAT_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::NavSAT_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::NavSAT_<ContainerAllocator> > {
+  typedef ublox_msgs::NavSAT_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.iTOW);
     stream.next(m.version);
@@ -299,31 +332,35 @@ struct Serializer<ublox_msgs::NavSAT_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.sv[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::NavSAT_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + 12 * m.numSvs;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::NavSAT_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.sv.size() != m.numSvs) {
       ROS_ERROR("NavSAT numSvs must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);
     stream.next(m.version);
-    stream.next(static_cast<typename ublox_msgs::NavSAT_<ContainerAllocator>::_numSvs_type>(m.sv.size()));
+    stream.next(static_cast<typename Msg::_numSvs_type>(m.sv.size()));
     stream.next(m.reserved0);
     for(std::size_t i = 0; i < m.sv.size(); ++i) 
       ros::serialization::serialize(stream, m.sv[i]);
   }
 };
 
+///
+/// @brief Serializes the NavDGPS message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::NavSVINFO_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::NavSVINFO_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::NavSVINFO_<ContainerAllocator> > {
+  typedef ublox_msgs::NavSVINFO_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.iTOW);
     stream.next(m.numCh);
@@ -334,19 +371,18 @@ struct Serializer<ublox_msgs::NavSVINFO_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.sv[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::NavSVINFO_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + 12 * m.numCh;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::NavSVINFO_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.sv.size() != m.numCh) {
       ROS_ERROR("NavSVINFO numCh must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);
-    stream.next(static_cast<typename ublox_msgs::NavSVINFO_<ContainerAllocator>::_numCh_type>(m.sv.size()));
+    stream.next(static_cast<typename Msg::_numCh_type>(m.sv.size()));
     stream.next(m.globalFlags);
     stream.next(m.reserved2);
     for(std::size_t i = 0; i < m.sv.size(); ++i) 
@@ -354,11 +390,16 @@ struct Serializer<ublox_msgs::NavSVINFO_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the RxmRAW message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::RxmRAW_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::RxmRAW_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::RxmRAW_<ContainerAllocator> > {
+  typedef ublox_msgs::RxmRAW_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.rcvTOW);
     stream.next(m.week);
@@ -369,31 +410,35 @@ struct Serializer<ublox_msgs::RxmRAW_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.sv[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::RxmRAW_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + 24 * m.numSV;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::RxmRAW_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.sv.size() != m.numSV) {
       ROS_ERROR("RxmRAW numSV must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.rcvTOW);
     stream.next(m.week);
-    stream.next(static_cast<typename ublox_msgs::RxmRAW_<ContainerAllocator>::_numSV_type>(m.sv.size()));
+    stream.next(static_cast<typename Msg::_numSV_type>(m.sv.size()));
     stream.next(m.reserved1);
     for(std::size_t i = 0; i < m.sv.size(); ++i) 
       ros::serialization::serialize(stream, m.sv[i]);
   }
 };
 
+///
+/// @brief Serializes the RxmRAWX message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::RxmRAWX_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::RxmRAWX_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::RxmRAWX_<ContainerAllocator> > {
+  typedef ublox_msgs::RxmRAWX_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.rcvTOW);
     stream.next(m.week);
@@ -407,13 +452,12 @@ struct Serializer<ublox_msgs::RxmRAWX_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.meas[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::RxmRAWX_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 16 + 32 * m.numMeas;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::RxmRAWX_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.meas.size() != m.numMeas) {
       ROS_ERROR("RxmRAWX numMeas must equal meas size");
     }
@@ -421,7 +465,7 @@ struct Serializer<ublox_msgs::RxmRAWX_<ContainerAllocator> >
     stream.next(m.rcvTOW);
     stream.next(m.week);
     stream.next(m.leapS);
-    stream.next(static_cast<typename ublox_msgs::RxmRAWX_<ContainerAllocator>::_numMeas_type>(m.meas.size()));
+    stream.next(static_cast<typename Msg::_numMeas_type>(m.meas.size()));
     stream.next(m.recStat);
     stream.next(m.version);
     stream.next(m.reserved1);
@@ -430,11 +474,16 @@ struct Serializer<ublox_msgs::RxmRAWX_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the RxmSFRBX message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::RxmSFRBX_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::RxmSFRBX_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::RxmSFRBX_<ContainerAllocator> > {
+  typedef ublox_msgs::RxmSFRBX_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.gnssId);
     stream.next(m.svId);
@@ -449,13 +498,12 @@ struct Serializer<ublox_msgs::RxmSFRBX_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.dwrd[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::RxmSFRBX_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + 4 * m.numWords;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::RxmSFRBX_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.dwrd.size() != m.numWords) {
       ROS_ERROR("RxmSFRBX numWords must equal dwrd size");
     }
@@ -464,7 +512,7 @@ struct Serializer<ublox_msgs::RxmSFRBX_<ContainerAllocator> >
     stream.next(m.svId);
     stream.next(m.reserved0);
     stream.next(m.freqId);
-    stream.next(static_cast<typename ublox_msgs::RxmSFRBX_<ContainerAllocator>::_numWords_type>(m.dwrd.size()));
+    stream.next(static_cast<typename Msg::_numWords_type>(m.dwrd.size()));
     stream.next(m.chn);
     stream.next(m.version);
     stream.next(m.reserved1);
@@ -473,11 +521,16 @@ struct Serializer<ublox_msgs::RxmSFRBX_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the RxmSVSI message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::RxmSVSI_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::RxmSVSI_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::RxmSVSI_<ContainerAllocator> > {
+  typedef ublox_msgs::RxmSVSI_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.iTOW);
     stream.next(m.week);
@@ -488,13 +541,12 @@ struct Serializer<ublox_msgs::RxmSVSI_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.sv[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::RxmSVSI_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + 6 * m.numSV;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::RxmSVSI_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.sv.size() != m.numSV) {
       ROS_ERROR("RxmSVSI numSV must equal sv size");
     }
@@ -502,40 +554,43 @@ struct Serializer<ublox_msgs::RxmSVSI_<ContainerAllocator> >
     stream.next(m.iTOW);
     stream.next(m.week);
     stream.next(m.numVis);
-    stream.next(static_cast<typename ublox_msgs::RxmSVSI_<ContainerAllocator>::_numSV_type>(m.sv.size()));
+    stream.next(static_cast<typename Msg::_numSV_type>(m.sv.size()));
     for(std::size_t i = 0; i < m.sv.size(); ++i) 
       ros::serialization::serialize(stream, m.sv[i]);
   }
 };
 
+///
+/// @brief Serializes the RxmALM message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::RxmALM_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::RxmALM_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::RxmALM_<ContainerAllocator> > {
+  typedef ublox_msgs::RxmALM_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.svid);
     stream.next(m.week);
 
     m.dwrd.clear();
-    try {
-      typename ublox_msgs::RxmALM_<ContainerAllocator>::_dwrd_type::value_type temp;
-
+    if(count == 40) {
+      typename Msg::_dwrd_type::value_type temp;
+      m.dwrd.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp);
         m.dwrd.push_back(temp);
       }
-    } catch(ros::serialization::StreamOverrunException& e) {
     }
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::RxmALM_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + (4 * m.dwrd.size());
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::RxmALM_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     stream.next(m.svid);
     stream.next(m.week);
@@ -544,11 +599,17 @@ struct Serializer<ublox_msgs::RxmALM_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the RxmEPH message which has a repeated block.
+///
 template <typename ContainerAllocator>
 struct Serializer<ublox_msgs::RxmEPH_<ContainerAllocator> >
 {
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::RxmEPH_<ContainerAllocator> >::reference m)
-  {
+  typedef ublox_msgs::RxmEPH_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.svid);
     stream.next(m.how);
@@ -556,34 +617,35 @@ struct Serializer<ublox_msgs::RxmEPH_<ContainerAllocator> >
     m.sf2d.clear();
     m.sf3d.clear();
 
-    try {
-      typename ublox_msgs::RxmEPH_<ContainerAllocator>::_sf1d_type::value_type temp1;
-      typename ublox_msgs::RxmEPH_<ContainerAllocator>::_sf2d_type::value_type temp2;
-      typename ublox_msgs::RxmEPH_<ContainerAllocator>::_sf3d_type::value_type temp3;
+    if (count == 104) {
+      typename Msg::_sf1d_type::value_type temp1;
+      typename Msg::_sf2d_type::value_type temp2;
+      typename Msg::_sf3d_type::value_type temp3;
 
+      m.sf1d.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp1);
         m.sf1d.push_back(temp1);
       }
+      m.sf2d.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp2);
         m.sf2d.push_back(temp2);
       }
+      m.sf3d.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp3);
         m.sf3d.push_back(temp3);
       }
-    } catch(ros::serialization::StreamOverrunException& e) {
     }
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::RxmEPH_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + (4 * m.sf1d.size()) + (4 * m.sf2d.size()) + (4 * m.sf3d.size());
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::RxmEPH_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     stream.next(m.svid);
     stream.next(m.how);
@@ -596,36 +658,37 @@ struct Serializer<ublox_msgs::RxmEPH_<ContainerAllocator> >
   }
 };
 
-/////////////////////////////////////////////////
-
+///
+/// @brief Serializes the AidALM message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::AidALM_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::AidALM_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::AidALM_<ContainerAllocator> > {
+  typedef ublox_msgs::AidALM_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.svid);
     stream.next(m.week);
 
     m.dwrd.clear();
-    try {
-      typename ublox_msgs::AidALM_<ContainerAllocator>::_dwrd_type::value_type temp;
-
+    if (count == 40) {
+      typename Msg::_dwrd_type::value_type temp;
+      m.dwrd.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp);
         m.dwrd.push_back(temp);
       }
-    } catch(ros::serialization::StreamOverrunException& e) {
-    }
+    } 
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::AidALM_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + (4 * m.dwrd.size());
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::AidALM_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     stream.next(m.svid);
     stream.next(m.week);
@@ -634,11 +697,17 @@ struct Serializer<ublox_msgs::AidALM_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the AidEPH message which has a repeated block.
+///
 template <typename ContainerAllocator>
 struct Serializer<ublox_msgs::AidEPH_<ContainerAllocator> >
 {
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::AidEPH_<ContainerAllocator> >::reference m)
-  {
+  typedef ublox_msgs::AidEPH_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.svid);
     stream.next(m.how);
@@ -646,34 +715,34 @@ struct Serializer<ublox_msgs::AidEPH_<ContainerAllocator> >
     m.sf2d.clear();
     m.sf3d.clear();
 
-    try {
-      typename ublox_msgs::AidEPH_<ContainerAllocator>::_sf1d_type::value_type temp1;
-      typename ublox_msgs::AidEPH_<ContainerAllocator>::_sf2d_type::value_type temp2;
-      typename ublox_msgs::AidEPH_<ContainerAllocator>::_sf3d_type::value_type temp3;
-
+    if (count == 104) {
+      typename Msg::_sf1d_type::value_type temp1;
+      typename Msg::_sf2d_type::value_type temp2;
+      typename Msg::_sf3d_type::value_type temp3;
+      m.sf1d.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp1);
         m.sf1d.push_back(temp1);
       }
+      m.sf2d.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp2);
         m.sf2d.push_back(temp2);
       }
+      m.sf3d.resize(8);
       for(std::size_t i = 0; i < 8; ++i) {
         stream.next(temp3);
         m.sf3d.push_back(temp3);
       }
-    } catch(ros::serialization::StreamOverrunException& e) {
     }
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::AidEPH_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 8 + (4 * m.sf1d.size()) + (4 * m.sf2d.size()) + (4 * m.sf3d.size());
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::AidEPH_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     stream.next(m.svid);
     stream.next(m.how);
@@ -686,11 +755,17 @@ struct Serializer<ublox_msgs::AidEPH_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the EsfMEAS message which has a repeated block and an
+/// optional block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::EsfMEAS_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::EsfMEAS_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::EsfMEAS_<ContainerAllocator> > {
+  typedef boost::call_traits<ublox_msgs::EsfMEAS_<ContainerAllocator> > 
+      CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.timeTag);
     stream.next(m.flags);
@@ -709,14 +784,12 @@ struct Serializer<ublox_msgs::EsfMEAS_<ContainerAllocator> >
     }
   }
 
-
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::EsfMEAS_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 4 + 8 * m.data.size() + 4 * m.calibTtag.size();
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::EsfMEAS_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     stream.next(m.timeTag);
     stream.next(m.flags);
@@ -728,11 +801,16 @@ struct Serializer<ublox_msgs::EsfMEAS_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the EsfRAW message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::EsfRAW_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::EsfRAW_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::EsfRAW_<ContainerAllocator> > {
+  typedef boost::call_traits<ublox_msgs::EsfRAW_<ContainerAllocator> > 
+      CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.reserved0);
     m.blocks.clear();
@@ -743,13 +821,12 @@ struct Serializer<ublox_msgs::EsfRAW_<ContainerAllocator> >
   }
 
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::EsfRAW_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 4 + 8 * m.blocks.size();
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::EsfRAW_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     ros::serialization::OStream stream(data, size);
     stream.next(m.reserved0);
     for(std::size_t i = 0; i < m.blocks.size(); ++i) 
@@ -757,11 +834,16 @@ struct Serializer<ublox_msgs::EsfRAW_<ContainerAllocator> >
   }
 };
 
+///
+/// @brief Serializes the EsfSTATUS message which has a repeated block.
+///
 template <typename ContainerAllocator>
-struct Serializer<ublox_msgs::EsfSTATUS_<ContainerAllocator> >
-{
-  static void read(const uint8_t *data, uint32_t count, typename boost::call_traits<ublox_msgs::EsfSTATUS_<ContainerAllocator> >::reference m)
-  {
+struct Serializer<ublox_msgs::EsfSTATUS_<ContainerAllocator> > {
+  typedef ublox_msgs::EsfSTATUS_<ContainerAllocator> Msg;
+  typedef boost::call_traits<Msg> CallTraits;
+
+  static void read(const uint8_t *data, uint32_t count, 
+                   typename CallTraits::reference m) {
     ros::serialization::IStream stream(const_cast<uint8_t *>(data), count);
     stream.next(m.iTOW);
     stream.next(m.version);
@@ -773,13 +855,12 @@ struct Serializer<ublox_msgs::EsfSTATUS_<ContainerAllocator> >
       ros::serialization::deserialize(stream, m.sens[i]);
   }
 
-  static uint32_t serializedLength (typename boost::call_traits<ublox_msgs::EsfSTATUS_<ContainerAllocator> >::param_type m)
-  {
+  static uint32_t serializedLength (typename CallTraits::param_type m) {
     return 16 + 4 * m.numSens;
   }
 
-  static void write(uint8_t *data, uint32_t size, typename boost::call_traits<ublox_msgs::EsfSTATUS_<ContainerAllocator> >::param_type m)
-  {
+  static void write(uint8_t *data, uint32_t size, 
+                    typename CallTraits::param_type m) {
     if(m.sens.size() != m.numSens) {
       ROS_ERROR("Writing EsfSTATUS message: numSens must equal size of sens");
     }
@@ -788,7 +869,7 @@ struct Serializer<ublox_msgs::EsfSTATUS_<ContainerAllocator> >
     stream.next(m.version);
     stream.next(m.fusionMode);
     stream.next(m.reserved2);
-    stream.next(static_cast<typename ublox_msgs::EsfSTATUS_<ContainerAllocator>::_numSens_type>(m.sens.size()));
+    stream.next(static_cast<typename Msg::_numSens_type>(m.sens.size()));
     for(std::size_t i = 0; i < m.sens.size(); ++i) 
       ros::serialization::serialize(stream, m.sens[i]);
   }

--- a/ublox_msgs/include/ublox/serialization/ublox_msgs.h
+++ b/ublox_msgs/include/ublox/serialization/ublox_msgs.h
@@ -34,9 +34,11 @@
 #include <ublox/serialization.h>
 #include <ublox_msgs/ublox_msgs.h>
 
+///
 /// This file declares custom serializers for u-blox messages with dynamic 
 /// lengths and messages where the get/set messages have different sizes, but
 /// share the same parameters, such as CfgDAT.
+///
 
 namespace ublox {
 

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.h
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.h
@@ -61,6 +61,7 @@
 #include <ublox_msgs/RxmSVSI.h>
 
 #include <ublox_msgs/Inf.h>
+#include <ublox_msgs/Ack.h>
 
 #include <ublox_msgs/CfgANT.h>
 #include <ublox_msgs/CfgCFG.h>

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.h
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.h
@@ -82,6 +82,7 @@
 #include <ublox_msgs/CfgRST.h>
 #include <ublox_msgs/CfgSBAS.h>
 #include <ublox_msgs/CfgTMODE3.h>
+#include <ublox_msgs/CfgUSB.h>
 
 #include <ublox_msgs/UpdSOS.h>
 #include <ublox_msgs/UpdSOS_Ack.h>
@@ -214,10 +215,11 @@ namespace Message {
     static const uint8_t RST = CfgRST::MESSAGE_ID;
     static const uint8_t SBAS = CfgSBAS::MESSAGE_ID;
     static const uint8_t TMODE3 = CfgTMODE3::MESSAGE_ID;
+    static const uint8_t USB = CfgUSB::MESSAGE_ID;
   }
 
   namespace UPD {
-    //!< SOS and SOS_Ack have the same message ID, but different lengths
+    //! SOS and SOS_Ack have the same message ID, but different lengths
     static const uint8_t SOS = UpdSOS::MESSAGE_ID;
   }
   

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.h
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.h
@@ -82,6 +82,9 @@
 #include <ublox_msgs/CfgSBAS.h>
 #include <ublox_msgs/CfgTMODE3.h>
 
+#include <ublox_msgs/UpdSOS.h>
+#include <ublox_msgs/UpdSOS_Ack.h>
+
 #include <ublox_msgs/MonGNSS.h>
 #include <ublox_msgs/MonHW.h>
 #include <ublox_msgs/MonVER.h>
@@ -116,6 +119,10 @@ namespace Class {
   // Configuration Input Messages: Set Dynamic Model, Set DOP Mask, Set Baud 
   // Rate, etc.
   static const uint8_t CFG = 0x06; 
+  // Firmware Update Messages: i.e. Memory/Flash erase/write, Reboot, Flash 
+  // identification, etc..
+  // Used to update the firmware and identify any attached flash device
+  static const uint8_t UPD = 0x09;
   // Monitoring Messages: Comunication Status, CPU Load, Stack Usage, Task 
   // Status
   static const uint8_t MON = 0x0A; 
@@ -208,6 +215,11 @@ namespace Message {
     static const uint8_t RST = CfgRST::MESSAGE_ID;
     static const uint8_t SBAS = CfgSBAS::MESSAGE_ID;
     static const uint8_t TMODE3 = CfgTMODE3::MESSAGE_ID;
+  }
+
+  namespace UPD {
+    // SOS and SOS_Ack have the same message ID, but different lengths
+    static const uint8_t SOS = UpdSOS::MESSAGE_ID;
   }
   
   namespace MON {

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.h
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.h
@@ -107,44 +107,42 @@
 namespace ublox_msgs {
 
 namespace Class {
-  // Navigation Result Messages: Position, Speed, Time, Acceleration, Heading, 
-  // DOP, SVs used
-  static const uint8_t NAV = 0x01; 
-  // Receiver Manager Messages: Satellite Status, RTC Status
-  static const uint8_t RXM = 0x02; 
-  // Information Messages: Printf-Style Messages, with IDs such as Error, 
-  // Warning, Notice
-  static const uint8_t INF = 0x04; 
-  // Ack/Nack Messages: Acknowledge or Reject messages to CFG input messages
-  static const uint8_t ACK = 0x05; 
-  // Configuration Input Messages: Set Dynamic Model, Set DOP Mask, Set Baud 
-  // Rate, etc.
-  static const uint8_t CFG = 0x06; 
-  // Firmware Update Messages: i.e. Memory/Flash erase/write, Reboot, Flash 
-  // identification, etc..
-  // Used to update the firmware and identify any attached flash device
-  static const uint8_t UPD = 0x09;
-  // Monitoring Messages: Comunication Status, CPU Load, Stack Usage, Task 
-  // Status
-  static const uint8_t MON = 0x0A; 
-  // AssistNow Aiding Messages: Ephemeris, Almanac, other A-GPS data input
-  static const uint8_t AID = 0x0B; 
-  // Timing Messages: Timepulse Output, Timemark Results
-  static const uint8_t TIM = 0x0D; 
-  // External Sensor Fusion Messages: External sensor measurements and status 
-  // information
-  static const uint8_t ESF = 0x10; 
-  // Multiple GNSS Assistance Messages: Assistance data for various GNSS
-  static const uint8_t MGA = 0x13;
-  // Logging Messages: Log creation, deletion, info and retrieval
-  static const uint8_t LOG = 0x21;
-  // Security Feature Messages
-  static const uint8_t SEC = 0x27;
-  // High Rate Navigation Results Messages: High rate time, position, speed, 
-  // heading
-  static const uint8_t HNR = 0x28;
-  // RTCM Configuration Messages
-  static const uint8_t RTCM = 0xF5;
+  static const uint8_t NAV = 0x01; //!< Navigation Result Messages: Position, 
+                                   //!< Speed, Time, Acceleration, Heading, 
+                                   //!< DOP, SVs used
+  static const uint8_t RXM = 0x02; //!< Receiver Manager Messages: 
+                                   //!< Satellite Status, RTC Status
+  static const uint8_t INF = 0x04; //!< Information Messages: 
+                                   //!< Printf-Style Messages, with IDs such as
+                                   //!< Error, Warning, Notice
+  static const uint8_t ACK = 0x05; //!< Ack/Nack Messages: Acknowledge or Reject 
+                                   //!< messages to CFG input messages
+  static const uint8_t CFG = 0x06; //!< Configuration Input Messages: Set 
+                                   //!< Dynamic Model, Set DOP Mask, Set Baud 
+                                   //!< Rate, etc.
+  static const uint8_t UPD = 0x09; //!< Firmware Update Messages: i.e. 
+                                   //!< Memory/Flash erase/write, Reboot, Flash 
+                                   //!< identification, etc.
+                                   //!< Used to update the firmware and identify 
+                                   //!< any attached flash device
+  static const uint8_t MON = 0x0A; //!< Monitoring Messages: Communication 
+                                   //!< Status, CPU Load, Stack Usage, 
+                                   //!< Task Status
+  static const uint8_t AID = 0x0B; //!< AssistNow Aiding Messages: Ephemeris, 
+                                   //!< Almanac, other A-GPS data input
+  static const uint8_t TIM = 0x0D; //!< Timing Messages: Timepulse Output, 
+                                   //!< Timemark Results
+  static const uint8_t ESF = 0x10; //!< External Sensor Fusion Messages: 
+                                   //!< External sensor measurements and status 
+                                   //!< information
+  static const uint8_t MGA = 0x13; //!< Multiple GNSS Assistance Messages: 
+                                   //!< Assistance data for various GNSS
+  static const uint8_t LOG = 0x21; //!< Logging Messages: Log creation, 
+                                   //!< deletion, info and retrieval
+  static const uint8_t SEC = 0x27; //!< Security Feature Messages
+  static const uint8_t HNR = 0x28; //!< High Rate Navigation Results Messages: 
+                                   //!< High rate time, position, speed, heading
+  static const uint8_t RTCM = 0xF5; //!< RTCM Configuration Messages
 }
 
 namespace Message {
@@ -219,7 +217,7 @@ namespace Message {
   }
 
   namespace UPD {
-    // SOS and SOS_Ack have the same message ID, but different lengths
+    //!< SOS and SOS_Ack have the same message ID, but different lengths
     static const uint8_t SOS = UpdSOS::MESSAGE_ID;
   }
   
@@ -245,6 +243,6 @@ namespace Message {
   }
 }
 
-} // namespace ublox_msgs
+} //!< namespace ublox_msgs
 
-#endif // UBLOX_MSGS_H
+#endif //!< UBLOX_MSGS_H

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.h
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.h
@@ -89,6 +89,7 @@
 
 #include <ublox_msgs/MonGNSS.h>
 #include <ublox_msgs/MonHW.h>
+#include <ublox_msgs/MonHW6.h>
 #include <ublox_msgs/MonVER.h>
 
 #include <ublox_msgs/AidALM.h>

--- a/ublox_msgs/msg/Ack.msg
+++ b/ublox_msgs/msg/Ack.msg
@@ -1,0 +1,12 @@
+# ACK (0x05)
+# Message Acknowledged / Not-Acknowledged
+#
+# Output upon processing of an input message
+#
+
+uint8 CLASS_ID = 5
+uint8 NACK_MESSAGE_ID = 0
+uint8 ACK_MESSAGE_ID = 1
+
+uint8 clsID   # Class ID of the (Not-)Acknowledged Message
+uint8 msgID   # Message ID of the (Not-)Acknowledged Message

--- a/ublox_msgs/msg/AidEPH.msg
+++ b/ublox_msgs/msg/AidEPH.msg
@@ -20,7 +20,8 @@
 uint8 CLASS_ID = 11
 uint8 MESSAGE_ID = 49
 
-uint32 svid             # SV ID for which this ephemeris data is (Valid Range: 1 .. 32).
+uint32 svid             # SV ID for which this ephemeris data is 
+                        # (Valid Range: 1 .. 32).
 uint32 how              # Hand-Over Word of first Subframe. This is
                         # required if data is sent to the receiver.
                         # 0 indicates that no Ephemeris Data is following.

--- a/ublox_msgs/msg/CfgNAVX5.msg
+++ b/ublox_msgs/msg/CfgNAVX5.msg
@@ -21,43 +21,47 @@ uint16 MASK1_AOP            = 16384    # apply aopCfg (useAOP flag) and
                                        # (AssistNow Autonomous)
 
 uint32 mask2          # Second parameters bitmask (possible values below)
+                      # Firmware >=8 only
 uint32 MASK2_ADR = 64                    # Apply ADR sensor fusion on/off 
                                          # setting
 uint32 MASK2_SIG_ATTEN_COMP_MODE = 128   # Apply signal attenuation 
                                          # compensation feature settings
 
-uint8[2] reserved1    # Always set to zero
+uint8[2] reserved1      # Always set to zero
 
-uint8 minSVs          # Minimum number of satellites for navigation
-uint8 maxSVs          # Maximum number of satellites for navigation
-uint8 minCNO          # Minimum satellite signal level for navigation [dBHz]
+uint8 minSVs            # Minimum number of satellites for navigation
+uint8 maxSVs            # Maximum number of satellites for navigation
+uint8 minCNO            # Minimum satellite signal level for navigation [dBHz]
 
-uint8 reserved2       # Always set to zero
+uint8 reserved2         # Always set to zero
 
-uint8 iniFix3D        # If set to 1, initial fix must be 3D
+uint8 iniFix3D          # If set to 1, initial fix must be 3D
 
-uint8[2] reserved3    # Always set to zero
+uint8[2] reserved3      # Always set to zero
 
-uint8 ackAiding       # If set to 1, issue acknowledgments for assistance
-uint16 wknRollover    # GPS week rollover number, GPS week numbers will be set 
-                      # correctly from this week up to 1024 weeks after this 
-                      # week
-uint8 sigAttenCompMode # Permanently attenuated signal compensation [dBHz]
-                       # 0 = disabled, 255 = automatic
-                       # 1..63 = maximum expected C/N0 value
+uint8 ackAiding         # If set to 1, issue acknowledgments for assistance
+uint16 wknRollover      # GPS week rollover number, GPS week numbers will be set 
+                        # correctly from this week up to 1024 weeks after this 
+                        # week
+uint8 sigAttenCompMode  # Permanently attenuated signal compensation [dBHz]
+                        # 0 = disabled, 255 = automatic
+                        # 1..63 = maximum expected C/N0 value
+                        # Firmware 8 only
 
-uint8[5] reserved4    # Always set to zero
+uint8[5] reserved4      # Always set to zero
 
-uint8 usePPP          # Enable/disable PPP (on supported units)
-uint8 aopCfg          # AssistNow Autonomous configuration, 1: enabled
+uint8 usePPP            # Enable/disable PPP (on supported units)
+uint8 aopCfg            # AssistNow Autonomous configuration, 1: enabled
 
-uint8[2] reserved5    # Always set to zero
+uint8[2] reserved5      # Always set to zero
 
-uint16 aopOrbMaxErr   # Maximum acceptable (modeled) autonomous orbit error [m]
-                      # valid range = 5..1000, or 0 = reset to firmware default
+uint16 aopOrbMaxErr     # Maximum acceptable (modeled) autonomous orbit 
+                        # error [m]
+                        # valid range = 5..1000
+                        # 0 = reset to firmware default
 
-uint8[7] reserved6    # Always set to zero
+uint8[7] reserved6      # Always set to zero
 
-uint8 useAdr          # Enable/disable ADR sensor fusion 
-                      # 1: enabled, 0: disabled
-                      # Only supported on certain products 
+uint8 useAdr            # Enable/disable ADR sensor fusion 
+                        # 1: enabled, 0: disabled
+                        # Only supported on certain products 

--- a/ublox_msgs/msg/CfgUSB.msg
+++ b/ublox_msgs/msg/CfgUSB.msg
@@ -20,11 +20,11 @@ uint16 flags                # various configuration flags (see graphic below)
 uint16 FLAGS_RE_ENUM = 0       # force re-enumeration
 uint16 FLAGS_POWER_MODE = 2    # self-powered (1), bus-powered (0)
 
-uint8[32] vendorString      # String containing the vendor name. 
-                            # 32 ASCII bytes including 0-termination.
-uint8[32] productString     # String containing the product name. 
-                            # 32 ASCII bytes including 0-termination.
-uint8[32] serialNumber      # String containing the serial number. 
-                            # 32 ASCII bytes including 0-termination. 
-                            # Changing the String fields requires special Host 
-                            # drivers.
+int8[32] vendorString      # String containing the vendor name. 
+                           # 32 ASCII bytes including 0-termination.
+int8[32] productString     # String containing the product name. 
+                           # 32 ASCII bytes including 0-termination.
+int8[32] serialNumber      # String containing the serial number. 
+                           # 32 ASCII bytes including 0-termination. 
+                           # Changing the String fields requires special Host 
+                           # drivers.

--- a/ublox_msgs/msg/CfgUSB.msg
+++ b/ublox_msgs/msg/CfgUSB.msg
@@ -1,0 +1,30 @@
+# UBX-CFG-USB (0x06 0x1B)
+# USB Configuration
+#
+
+uint8 CLASS_ID = 6
+uint8 MESSAGE_ID = 27 
+
+uint16 vendorID             # Only set to registered Vendor IDs.                     
+                            # Changing this field requires special Host drivers.
+
+uint16 productID            # Product ID. Changing this field requires special  
+                            # Host drivers.
+
+uint8[2] reserved1          # Reserved
+uint8[2] reserved2          # Reserved
+
+uint16 powerConsumption     # Power consumed by the device [mA]
+
+uint16 flags                # various configuration flags (see graphic below)
+uint16 FLAGS_RE_ENUM = 0       # force re-enumeration
+uint16 FLAGS_POWER_MODE = 2    # self-powered (1), bus-powered (0)
+
+uint8[32] vendorString      # String containing the vendor name. 
+                            # 32 ASCII bytes including 0-termination.
+uint8[32] productString     # String containing the product name. 
+                            # 32 ASCII bytes including 0-termination.
+uint8[32] serialNumber      # String containing the serial number. 
+                            # 32 ASCII bytes including 0-termination. 
+                            # Changing the String fields requires special Host 
+                            # drivers.

--- a/ublox_msgs/msg/MonHW6.msg
+++ b/ublox_msgs/msg/MonHW6.msg
@@ -1,0 +1,58 @@
+# MON-HW (0x0A 0x09)
+# Hardware Status
+# Firmware 6
+#
+# Status of different aspect of the hardware, such as Antenna, PIO/Peripheral 
+# Pins, Noise Level, Automatic Gain Control (AGC)
+#
+# WARNING: this message is a different length than the MonHW message for
+# firmware version 7 & 8
+
+uint8 CLASS_ID = 10
+uint8 MESSAGE_ID = 9
+
+uint32 pinSel                 # Mask of Pins Set as Peripheral/PIO
+uint32 pinBank                # Mask of Pins Set as Bank A/B
+uint32 pinDir                 # Mask of Pins Set as Input/Output
+uint32 pinVal                 # Mask of Pins Value Low/High
+uint16 noisePerMS             # Noise Level as measured by the GPS Core
+uint16 agcCnt                 # AGC Monitor (counts SIGHI xor SIGLO, 
+                              # range 0 to 8191)
+uint8 aStatus                 # Status of the Antenna Supervisor State Machine 
+uint8 A_STATUS_INIT = 0
+uint8 A_STATUS_UNKNOWN = 1
+uint8 A_STATUS_OK = 2
+uint8 A_STATUS_SHORT = 3
+uint8 A_STATUS_OPEN = 4
+
+uint8 aPower                  # Current PowerStatus of Antenna 
+uint8 A_POWER_OFF = 0 
+uint8 A_POWER_ON = 1
+uint8 A_POWER_UNKNOWN = 2
+
+uint8 flags                   # Flags:
+uint8 FLAGS_RTC_CALIB = 1            # RTC is calibrated
+uint8 FLAGS_SAFE_BOOT =  2           # Safe boot mode (0 = inactive, 1 = active)
+uint8 FLAGS_JAMMING_STATE_MASK = 12  # output from Jamming/Interference Monitor: 
+uint8 JAMMING_STATE_UNKNOWN_OR_DISABLED = 0   # unknown or feature disabled
+uint8 JAMMING_STATE_OK = 4                    # ok - no significant jamming
+uint8 JAMMING_STATE_WARNING = 8               # interference visible but fix OK
+uint8 JAMMING_STATE_CRITICAL = 12             # interference visible and no fix
+uint8 FLAGS_XTAL_ABSENT =  16        # RTC XTAL is absent
+                                     # (not supported in protocol versions < 18)
+uint8 reserved0               # Reserved
+uint32 usedMask               # Mask of Pins that are used by the Virtual Pin 
+                              # Manager
+uint8[25] VP                  # Array of Pin Mappings for each of the 25  
+                              # Physical Pins
+uint8 jamInd                  # CW Jamming indicator, scaled:
+uint8 JAM_IND_NONE = 0          # No CW Jamming
+uint8 JAM_IND_STRONG = 255      # Strong CW Jamming    
+
+uint8[2] reserved1            # Reserved
+
+uint32 pinIrq                 # Mask of Pins Value using the PIO Irq
+uint32 pullH                  # Mask of Pins Value using the PIO Pull High 
+                              # Resistor
+uint32 pullL                  # Mask of Pins Value using the PIO Pull Low 
+                              # Resistor

--- a/ublox_msgs/msg/NavDGPS.msg
+++ b/ublox_msgs/msg/NavDGPS.msg
@@ -6,7 +6,7 @@
 #
 
 uint8 CLASS_ID = 1
-uint8 MESSAGE_ID = 31
+uint8 MESSAGE_ID = 49
 
 uint32 iTOW             # GPS Millisecond time of week [ms]
 

--- a/ublox_msgs/msg/UpdSOS.msg
+++ b/ublox_msgs/msg/UpdSOS.msg
@@ -1,0 +1,25 @@
+# UPD-SOS (0x09 0x14)
+#
+# Firmware Supported on:
+# u-blox 8 / u-blox M8 from protocol version 15 up to version 23.01
+#
+
+uint8 CLASS_ID = 9
+uint8 MESSAGE_ID = 20
+
+uint8 cmd                   # Command
+# The host can send this message in order to save part of the BBR memory in a 
+# file in flash file system. The feature is designed in order to emulate the 
+# presence of the backup battery even if it is not present; the host can issue 
+# the save on shutdown command before switching off the device supply. It is 
+# recommended to issue a GNSS stop command before, in order to keep the BBR 
+# memory content consistent.
+uint8 CMD_FLASH_BACKUP_CREATE = 0    # Create Backup File in Flash
+# The host can send this message in order to erase the backup file present in 
+# flash. It is recommended that the clear operation is issued after the host has 
+# received the notification that the memory has been restored after a reset. 
+# Alternatively the host can parse the startup string 'Restored data saved on 
+# shutdown' or poll the UBX-UPD-SOS message for getting the status.
+uint8 CMD_FLASH_BACKUP_CLEAR = 1     # Clear Backup File in Flash
+
+uint8[3] reserved1          # Reserved

--- a/ublox_msgs/msg/UpdSOS_Ack.msg
+++ b/ublox_msgs/msg/UpdSOS_Ack.msg
@@ -1,0 +1,38 @@
+# UPD-SOS (0x09 0x14)
+#
+# Backup File Creation Acknowledge / System Restored from Backup
+# 
+# Firmware Supported on:
+# u-blox 8 / u-blox M8 from protocol version 15 up to version 23.01
+#
+
+uint8 CLASS_ID = 9
+uint8 MESSAGE_ID = 20
+
+uint8 cmd                   # Command
+uint8 CMD_BACKUP_CREATE_ACK = 2   # Backup File Creation Acknowledge
+                                  # The message is sent from the device as 
+                                  # confirmation of creation of a backup file 
+                                  # in flash. The host can safely shut down the 
+                                  # device after received this message.
+uint8 CMD_SYSTEM_RESTORED = 3     # System Restored from Backup
+                                  # The message is sent from the device to 
+                                  # notify the host the BBR has been restored 
+                                  # from a backup file in flash. The host 
+                                  # should clear the backup file after 
+                                  # receiving this message. If the UBX-UPD-SOS 
+                                  # message is polled, this message will be 
+                                  # present.
+
+uint8[3] reserved0          # Reserved
+
+uint8 response                                  # Response:
+uint8 BACKUP_CREATE_NACK = 0                      # Not acknowledged
+uint8 BACKUP_CREATE_ACK = 1                       # Acknowledged
+uint8 SYSTEM_RESTORED_RESPONSE_UNKNOWN = 0        # Unknown
+uint8 SYSTEM_RESTORED_RESPONSE_FAILED = 1         # Failed restoring from backup 
+                                                  # file
+uint8 SYSTEM_RESTORED_RESPONSE_RESTORED = 2       # Restored from backup file
+uint8 SYSTEM_RESTORED_RESPONSE_NOT_RESTORED = 3   # Not restored (no backup)
+
+uint8[3] reserved1          # Reserved

--- a/ublox_msgs/package.xml
+++ b/ublox_msgs/package.xml
@@ -1,9 +1,9 @@
 <package>
   <name>ublox_msgs</name>
-  <version>1.1.0</version>
+  <version>1.1.2</version>
   <description>
 
-     ublox_msgs contains raw messages used by GNSS receiver modules of the company u-blox AG.
+     ublox_msgs contains raw messages for u-blox GNSS devices.
 
   </description>
   <author>Johannes Meyer</author>

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -143,6 +143,12 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::CFG, ublox_msgs::Message::CFG::RST,
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::CFG, ublox_msgs::Message::CFG::TMODE3, 
                       ublox_msgs, CfgTMODE3);
 
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::UPD, ublox_msgs::Message::UPD::SOS, 
+                      ublox_msgs, UpdSOS);
+// SOS and SOS_Ack have the same message ID, but different lengths
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::UPD, ublox_msgs::Message::UPD::SOS, 
+                      ublox_msgs, UpdSOS_Ack);
+
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::GNSS, 
                       ublox_msgs, MonGNSS);
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::HW, 

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -72,6 +72,13 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::VELECEF,
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::VELNED, 
                       ublox_msgs, NavVELNED);
 
+// ACK messages are declared differently because they both have the same 
+// protocol, so only 1 ROS message is used
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::ACK, ublox_msgs::Message::ACK::NACK, 
+                      ublox_msgs, Ack);
+DECLARE_UBLOX_MESSAGE_ID(ublox_msgs::Class::ACK, ublox_msgs::Message::ACK::ACK, 
+                      ublox_msgs, Ack, ACK);
+
 // INF messages are declared differently because they all have the same 
 // protocol, so only 1 ROS message is used. DECLARE_UBLOX_MESSAGE can only
 // be called once, and DECLARE_UBLOX_MESSAGE_ID is called for the following

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -162,6 +162,8 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::GNSS,
                       ublox_msgs, MonGNSS);
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::HW, 
                       ublox_msgs, MonHW);
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::HW, 
+                      ublox_msgs, MonHW6);
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::VER, 
                       ublox_msgs, MonVER);
 

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -149,6 +149,8 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::CFG, ublox_msgs::Message::CFG::RST,
                       ublox_msgs, CfgRST);
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::CFG, ublox_msgs::Message::CFG::TMODE3, 
                       ublox_msgs, CfgTMODE3);
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::CFG, ublox_msgs::Message::CFG::USB, 
+                      ublox_msgs, CfgUSB);
 
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::UPD, ublox_msgs::Message::UPD::SOS, 
                       ublox_msgs, UpdSOS);

--- a/ublox_serialization/include/ublox/checksum.h
+++ b/ublox_serialization/include/ublox/checksum.h
@@ -33,6 +33,13 @@
 
 namespace ublox {
 
+/**
+ * @brief calculate the checksum of a u-blox_message
+ * @param data the start of the u-blox message 
+ * @param data the size of the u-blox message
+ * @param ck_a the checksum a output
+ * @param ck_b the checksum b output
+ */
 static inline void calculateChecksum(const uint8_t *data, 
                                      uint32_t size, 
                                      uint8_t &ck_a, 
@@ -45,6 +52,13 @@ static inline void calculateChecksum(const uint8_t *data,
   }
 }
 
+/**
+ * @brief calculate the checksum of a u-blox_message.
+ * @param data the start of the u-blox message 
+ * @param data the size of the u-blox message
+ * @param checksum the checksum output
+ * @return the checksum
+ */
 static inline uint16_t calculateChecksum(const uint8_t *data, 
                                          uint32_t size, 
                                          uint16_t &checksum) {

--- a/ublox_serialization/include/ublox/serialization.h
+++ b/ublox_serialization/include/ublox/serialization.h
@@ -37,14 +37,25 @@
 
 #include "checksum.h"
 
+///
+/// This file defines the Serializer template class which encodes and decodes
+/// specific message types. 
+/// The Reader class decodes messages and from a buffer and the Writer class 
+/// encodes messages and writes them to a buffer.
+/// It also declares macros for declaring Messages. The Message class
+/// maps ROS messages types to class and message ID(s).
+///
+
 namespace ublox {
 
-static const uint8_t DEFAULT_SYNC_A = 0xB5; //!< u-blox message Sync A char
-static const uint8_t DEFAULT_SYNC_B = 0x62; //!< u-blox message Sync B char
-static const uint8_t kHeaderLength = 6; //!< Number of bytes in a message header
-                                       //!< (Sync chars + class ID + message ID)
-static const uint8_t kWrapperLength = 8; //!< Number of bytes in the message 
-                                         //!< header and checksum 
+//! u-blox message Sync A char
+static const uint8_t DEFAULT_SYNC_A = 0xB5; 
+//! u-blox message Sync B char
+static const uint8_t DEFAULT_SYNC_B = 0x62; 
+//! Number of bytes in a message header (Sync chars + class ID + message ID)
+static const uint8_t kHeaderLength = 6; 
+//! Number of checksum bytes in the u-blox message
+static const uint8_t kChecksumLength = 2; 
 
 /**
  * @brief Encodes and decodes messages.
@@ -52,15 +63,17 @@ static const uint8_t kWrapperLength = 8; //!< Number of bytes in the message
 template <typename T>
 struct Serializer {
   /**
-   * @brief Decode the message from the data.
-   * @param data a pointer to the start of the message
-   * @param count the number of bytes in the message
+   * @brief Decode the message payload from the data buffer.
+   * @param data a pointer to the start of the message payload
+   * @param count the number of bytes in the message payload
    * @param message the output message
    */
   static void read(const uint8_t *data, uint32_t count, 
                    typename boost::call_traits<T>::reference message);
   /**
-   * @brief Get the length of the message in bytes.
+   * @brief Get the length of the message payload in bytes.
+   * 
+   * @details The payload does not include the header or checksum.
    * @param message the message to get the length of
    * @return the length of the message in bytes.
    */
@@ -68,8 +81,8 @@ struct Serializer {
       typename boost::call_traits<T>::param_type message);
   
   /**
-   * @brief Encode the message as a byte array.
-   * @param data a buffer to fill with the message bytes
+   * @brief Encode the message payload as a byte array.
+   * @param data a buffer to fill with the message payload bytes
    * @param size the length of the buffer
    * @param message the output message
    */
@@ -77,14 +90,30 @@ struct Serializer {
                     typename boost::call_traits<T>::param_type message);
 };
 
+/**
+ * @brief Keeps track of which class and message IDs can be decoded by a given
+ * message type.
+ */
 template <typename T>
 class Message {
  public:
+  /**
+   * @brief Can this message type decode a u-blox message with the given ID?
+   * @param class_id the class ID of the u-blox message
+   * @param message_id the message ID of the u-blox message
+   * @return whether or not this message type decode the u-blox message
+   */
   static bool canDecode(uint8_t class_id, uint8_t message_id) {
     return std::find(keys_.begin(), keys_.end(), 
                      std::make_pair(class_id, message_id)) != keys_.end();
   }
-
+  
+  /**
+   * @brief Indicate that this message type can decode u-blox messages with the 
+   * given ID
+   * @param class_id the class ID of the u-blox message
+   * @param message_id the message ID of the u-blox message
+   */
   static void addKey(uint8_t class_id, uint8_t message_id) {
     keys_.push_back(std::make_pair(class_id, message_id));
   }
@@ -100,10 +129,31 @@ class Message {
   static std::vector<std::pair<uint8_t,uint8_t> > keys_;
 };
 
-struct Options
-{
-  Options() : sync_a(DEFAULT_SYNC_A), sync_b(DEFAULT_SYNC_B) {}
-  uint8_t sync_a, sync_b;
+/**
+ * @brief Options for the Reader and Writer for encoding and decoding messages.
+ */
+struct Options {
+  /**
+   * The default options for a u-blox message.
+   */
+  Options() : sync_a(DEFAULT_SYNC_A), sync_b(DEFAULT_SYNC_B), 
+              header_length(kHeaderLength), checksum_length(kChecksumLength) {}
+  //! The sync_a byte value identifying the start of a message
+  uint8_t sync_a; 
+  //! The sync_b byte value identifying the start of a message
+  uint8_t sync_b; 
+  //! The length of the message header in bytes (everything before the payload)
+  uint8_t header_length; 
+  //! The length of the checksum in bytes
+  uint8_t checksum_length; 
+  
+  /**
+   * @brief Get the number of bytes in the header and footer.
+   * @return the number of bytes in the header and footer
+   */
+  int wrapper_length() {
+    return header_length + checksum_length; 
+  }
 };
 
 /** 
@@ -111,12 +161,22 @@ struct Options
  */
 class Reader {
  public:
+  /**
+   * @param data a buffer containing u-blox messages
+   * @param count the size of the buffer
+   * @param options A struct containing the parameters sync_a and sync_b  
+   * which represent the sync bytes indicating the beginning of the message
+   */
   Reader(const uint8_t *data, uint32_t count, 
          const Options &options = Options()) : 
       data_(data), count_(count), found_(false), options_(options) {}
 
   typedef const uint8_t *iterator;
 
+  /**
+   * @brief Search the buffer for the beginning of the next u-blox message
+   * @return a pointer to the start of the next u-blox message
+   */
   iterator search()
   {
     if (found_) next();
@@ -131,35 +191,46 @@ class Reader {
     return data_;
   }
 
-  // @returns true if A message with the correct header & length has been found
+  /**
+   * @brief Has a u-blox message been found in the buffer?
+   * @returns true if A message with the correct header & length has been found
+   */
   bool found()
   {
     if (found_) return true;
     // Verify message is long enough to have sync chars, id, length & checksum
-    if (count_ < kWrapperLength) return false;
+    if (count_ < options_.wrapper_length()) return false;
     // Verify the header bits
     if (data_[0] != options_.sync_a || data_[1] != options_.sync_b) 
       return false;
     // Verify that the buffer length is long enough based on the received
     // message length
-    if (count_ < length() + kWrapperLength) return false;
+    if (count_ < length() + options_.wrapper_length()) return false;
 
     found_ = true;
     return true;
   }
 
-  // @brief Go to the next message, uses the received message length.
-  // Warning: will not go to the correct byte location if the received message
-  // length is incorrect, still needs to be called after this.
+  /**
+   * @brief Go to the start of the next message based on the received message 
+   * length.
+   *
+   * @details Warning: Does not go to the correct byte location if the received 
+   * message length is incorrect. If this is the case, search must be called.
+   */
   iterator next() {
     if (found()) {
-      uint32_t size = length() + 8;
+      uint32_t size = length() + options_.wrapper_length();
       data_ += size; count_ -= size;
     }
     found_ = false;
     return data_;
   }
 
+  /**
+   * @brief Get the current position in the read buffer.
+   * @return the current position of the read buffer
+   */
   iterator pos() {
     return data_;
   }
@@ -170,10 +241,25 @@ class Reader {
 
   uint8_t classId() { return data_[2]; }
   uint8_t messageId() { return data_[3]; }
+
+  /**
+   * @brief Get the length of the u-blox message payload.
+   *
+   * @details Payload length does not include the header or checksum length.
+   * Determines the length from the header of the u-blox message.
+   * @return the length of the message payload
+   */
   uint32_t length() { return (data_[5] << 8) + data_[4]; }
-  const uint8_t *data() { return data_ + kHeaderLength; }
+  const uint8_t *data() { return data_ + options_.header_length; }
+  
+  /**
+   * @brief Get the checksum of the u-blox message.
+   *
+   * @return the checksum of the u-blox message
+   */
   uint16_t checksum() { 
-    return *reinterpret_cast<const uint16_t *>(data_ + kHeaderLength + length()); 
+    return *reinterpret_cast<const uint16_t *>(data_ + options_.header_length +
+                                               length()); 
   }
 
   /**
@@ -196,25 +282,40 @@ class Reader {
       return false;
     }
 
-    Serializer<T>::read(data_ + kHeaderLength, length(), message);
+    Serializer<T>::read(data_ + options_.header_length, length(), message);
     return true;
   }
 
-  template <typename T> bool hasType() {
+  /**
+   * @brief Can the given message type decode the current message in the buffer?
+   * @return whether the given message type can decode the current message in 
+   * the buffer
+   */
+  template <typename T> 
+  bool hasType() {
     if (!found()) return false;
     return Message<T>::canDecode(classId(), messageId());
   }
 
+  /**
+   * @brief Does the u-blox message have the given class and message ID?
+   * @return Whether or not the u-blox message has the given class and message 
+   * ID
+   */
   bool isMessage(uint8_t class_id, uint8_t message_id) {
     if (!found()) return false;
-    return (data_[2] == class_id && data_[3] == message_id);
+    return (classId() == class_id && messageId() == message_id);
   }
 
  private:
-  const uint8_t *data_;
-  uint32_t count_;
-  bool found_;
-  Options options_;
+  //! The buffer of message bytes
+  const uint8_t *data_; 
+  //! the number of bytes in the buffer, //! decrement as the buffer is read
+  uint32_t count_; 
+  //! Whether or not a message has been found
+  bool found_; 
+  //! Options representing the sync char values, etc.
+  Options options_; 
 };
 
 /** 
@@ -222,10 +323,16 @@ class Reader {
  */
 class Writer {
  public:
+  typedef uint8_t *iterator;
+
+  /**
+   * @brief Construct a Writer with the given buffer.
+   * @param data a buffer for messages
+   * @param size the size of the buffer
+   * @param options options representing the message sync chars, etc.
+   */
   Writer(uint8_t *data, uint32_t size, const Options &options = Options()) : 
       data_(data), size_(size), options_(options) {}
-
-  typedef uint8_t *iterator;
 
   /**
    * @brief Encode the u-blox message.
@@ -237,30 +344,36 @@ class Writer {
   template <typename T> bool write(const T& message, 
                                    uint8_t class_id = T::CLASS_ID, 
                                    uint8_t message_id = T::MESSAGE_ID) {
+    // Check for buffer overflow
     uint32_t length = Serializer<T>::serializedLength(message);
-    if (size_ < length + kWrapperLength) {
-      ROS_ERROR("U-Blox write %u / %u: size < length + 8", class_id, message_id);
+    if (size_ < length + options_.wrapper_length()) {
+      ROS_ERROR("u-blox write buffer overflow. Message %u / %u not written", 
+                class_id, message_id);
       return false;
     }
-    Serializer<T>::write(data_ + kHeaderLength, size_ - kHeaderLength, message);
+    // Encode the message and add it to the buffer
+    Serializer<T>::write(data_ + options_.header_length, 
+                         size_ - options_.header_length, message);
     return write(0, length, class_id, message_id);
   }
 
   /**
-   * @brief Encode the u-blox message.
-   * @param message the output message buffer
-   * @param length the length of the message
+   * @brief Wrap the encoded message payload with a header and checksum and
+   * add it to the buffer.
+   * @param message the encoded message payload (no header or checksum)
+   * @param length the length of the message payload
    * @param class_id the u-blox class ID
    * @param message_id the u-blox message ID
    * @return true if the message was encoded correctly, false otherwise
    */
   bool write(const uint8_t* message, uint32_t length, uint8_t class_id, 
              uint8_t message_id) {
-    if (size_ < length + kWrapperLength) {
-      ROS_ERROR("U-Blox write %u / %u: size < length + 8", class_id, message_id);
+    if (size_ < length + options_.wrapper_length()) {
+      ROS_ERROR("u-blox write buffer overflow. Message %u / %u not written", 
+                class_id, message_id);
       return false;
     }
-    uint8_t *start = data_;
+    iterator start = data_;
 
     // write header
     *data_++ = options_.sync_a;
@@ -269,7 +382,7 @@ class Writer {
     *data_++ = message_id;
     *data_++ = length & 0xFF;
     *data_++ = (length >> 8) & 0xFF;
-    size_ -= kHeaderLength;
+    size_ -= options_.header_length;
 
     // write message
     if (message) std::copy(message, message + length, data_);
@@ -281,7 +394,7 @@ class Writer {
     calculateChecksum(start + 2, length + 4, ck_a, ck_b);
     *data_++ = ck_a;
     *data_++ = ck_b;
-    size_ -= 2;
+    size_ -= options_.checksum_length;
 
     return true;
   }
@@ -291,13 +404,18 @@ class Writer {
   }
 
  private:
-  uint8_t *data_;
-  uint32_t size_;
-  Options options_;
+  //! The buffer of message bytes
+  iterator data_; 
+  //! The number of remaining bytes in the buffer
+  /*! Decrements as messages are written to the buffer */
+  uint32_t size_; 
+  //! Options representing the sync char values, etc.
+  Options options_; 
 };
 
 } // namespace ublox
 
+// Use to declare u-blox messages and message serializers
 #define DECLARE_UBLOX_MESSAGE(class_id, message_id, package, message) \
   template class ublox::Serializer<package::message>; \
   template class ublox::Message<package::message>; \

--- a/ublox_serialization/include/ublox/serialization.h
+++ b/ublox_serialization/include/ublox/serialization.h
@@ -46,6 +46,11 @@
 /// maps ROS messages types to class and message ID(s).
 ///
 
+
+/**
+ * @namespace ublox
+ * This namespace is for u-blox message serialization.
+ */
 namespace ublox {
 
 //! u-blox message Sync A char

--- a/ublox_serialization/package.xml
+++ b/ublox_serialization/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>ublox_serialization</name>
-  <version>1.1.0</version>
+  <version>1.1.2</version>
   <description>
 
      ublox_serialization provides header files for serialization of ROS messages to and from u-blox message format.


### PR DESCRIPTION
I know I'm a contributor now, but I wasn't sure if you guys wanted to look over changes before I merge them with the main branch. 

Tested on C94-M8P.

# BUG FIXES
  * NavSatFix messages for firmware >=7. The NavSatFix now only uses the NavPVT message time if it is valid, otherwise it uses ROS time.
  * TMODE3 Fixed mode configuration. The ARP High Precision position is now configured correctly. 
  * `NavDGPS` message which had the wrong Message ID.

# Device Configuration
* After GNSS configuration & reset, I/O resets automatically, without need for restart.

# New Messages
* `UBX-UPD` messages. For firmware version 8, the node can now save the flash memory on shutdown and clear the flash memory during configuration based on ROS params.
* `CfgGPS` message and `MonHW6` message for firmware version 6.

# Software Architecture
* Modified how the I/O stream is initialized so that the node now handles parsing the port string.
* Migrated all callback handling to `callback.h` from `gps.h` and `gps.cpp`. ACK messages are now processed through callback handlers.
* Changed class names of Ublox product components (e.g. UbloxTim -> TimProduct) for clarity.
* Cleaned up ublox custom serialization classes by adding typedefs and using count to determine repeating block statements instead of using try-catch statements to serialize stream.
* Added doxygen documentation

# Parameters
* Added respawn argument to example launch file.
* Changed name of "subscribe" parameter namespace to "publish" for clarity.
* Added parameters to load/save configuration.
* Added raw_data parameter for Raw Data Products.