### PR TITLE
Fixed bug causing GLONASS to stay enabled when re-configuring GNSS.

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -1150,7 +1150,7 @@ bool UbloxFirmware8::configureUblox() {
                && enable_glonass_ != (block.flags & block.FLAGS_ENABLE)) {
       correct = false;
       cfg_gnss.blocks[i].flags = 
-          (cfg_gnss.blocks[i].flags & ~enable_glonass_) | enable_glonass_;
+          (cfg_gnss.blocks[i].flags & ~block.FLAGS_ENABLE) | enable_glonass_;
       ROS_DEBUG("GLONASS Configuration is different");
     }
   }


### PR DESCRIPTION
^^
Now it's possible only to enable GLONASS, not disable. Tested on real device.

J.