### PR TITLE
added definitions for static in-class members

### DIFF
--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -276,7 +276,7 @@ class Gps {
    * @note This is part of the expert settings. It is recommended you check
    * the ublox manual first.
    */
-  bool setPpp(bool enable);
+  bool setPpp(bool enable, float protocol_version);
 
   /**
    * @brief Set the DGNSS mode (see CfgDGNSS message for details).
@@ -290,7 +290,7 @@ class Gps {
    * @param enable If true, enable ADR.
    * @return true on ACK, false on other conditions.
    */
-  bool setUseAdr(bool enable);
+  bool setUseAdr(bool enable, float protocol_version);
 
   /**
    * @brief Configure the U-Blox to UTC time 

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -1028,6 +1028,7 @@ class RawDataProduct: public virtual ComponentInterface {
  */
 class AdrUdrProduct: public virtual ComponentInterface {
  public:
+  AdrUdrProduct(float protocol_version);
   /**
    * @brief Get the ADR/UDR parameters.
    *
@@ -1062,6 +1063,8 @@ class AdrUdrProduct: public virtual ComponentInterface {
  protected:
   //! Whether or not to enable dead reckoning
   bool use_adr_;
+  
+  float protocol_version_;
 
    
   sensor_msgs::Imu imu_;

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -34,6 +34,10 @@ namespace ublox_gps {
 
 using namespace ublox_msgs;
 
+constexpr int Gps::kSetBaudrateSleepMs;
+constexpr double Gps::kDefaultAckTimeout;
+constexpr int Gps::kWriterSize;
+
 const boost::posix_time::time_duration Gps::default_timeout_ =
     boost::posix_time::milliseconds(
         static_cast<int>(Gps::kDefaultAckTimeout * 1000));

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -497,11 +497,13 @@ bool Gps::setDeadReckonLimit(uint8_t limit) {
   return configure(msg);
 }
 
-bool Gps::setPpp(bool enable) {
+bool Gps::setPpp(bool enable, float protocol_version) {
   ROS_DEBUG("%s PPP", (enable ? "Enabling" : "Disabling"));
 
   ublox_msgs::CfgNAVX5 msg;
   msg.usePPP = enable;
+  if(protocol_version >= 18)
+    msg.version = 2;
   msg.mask1 = ublox_msgs::CfgNAVX5::MASK1_PPP;
   return configure(msg);
 }
@@ -513,11 +515,14 @@ bool Gps::setDgnss(uint8_t mode) {
   return configure(cfg);
 }
 
-bool Gps::setUseAdr(bool enable) {
+bool Gps::setUseAdr(bool enable, float protocol_version) {
   ROS_DEBUG("%s ADR/UDR", (enable ? "Enabling" : "Disabling"));
 
   ublox_msgs::CfgNAVX5 msg;
   msg.useAdr = enable;
+  
+  if(protocol_version >= 18)
+    msg.version = 2;
   msg.mask2 = ublox_msgs::CfgNAVX5::MASK2_ADR;
   return configure(msg);
 }

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -127,7 +127,7 @@ void UbloxNode::addProductInterface(std::string product_category,
     components_.push_back(ComponentPtr(new TimProduct));
   else if (product_category.compare("ADR") == 0 ||
            product_category.compare("UDR") == 0)
-    components_.push_back(ComponentPtr(new AdrUdrProduct));
+    components_.push_back(ComponentPtr(new AdrUdrProduct(protocol_version_)));
   else if (product_category.compare("FTS") == 0)
     components_.push_back(ComponentPtr(new FtsProduct));
   else if(product_category.compare("SPG") != 0)
@@ -452,7 +452,7 @@ bool UbloxNode::configureUblox() {
                                  " SBAS.");
       }
     }
-    if (!gps.setPpp(enable_ppp_))
+    if (!gps.setPpp(enable_ppp_, protocol_version_))
       throw std::runtime_error(std::string("Failed to ") +
                                ((enable_ppp_) ? "enable" : "disable")
                                + " PPP.");
@@ -1265,6 +1265,10 @@ void RawDataProduct::initializeRosDiagnostics() {
                                                kRtcmFreqWindow));
 }
 
+AdrUdrProduct::AdrUdrProduct(float protocol_version)
+    : protocol_version_(protocol_version)
+{}
+
 //
 // u-blox ADR devices, partially implemented
 //
@@ -1277,7 +1281,7 @@ void AdrUdrProduct::getRosParams() {
 }
 
 bool AdrUdrProduct::configureUblox() {
-  if(!gps.setUseAdr(use_adr_))
+  if(!gps.setUseAdr(use_adr_, protocol_version_))
     throw std::runtime_error(std::string("Failed to ")
                              + (use_adr_ ? "enable" : "disable") + "use_adr");
   return true;

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -37,6 +37,21 @@ using namespace ublox_node;
 //
 // ublox_node namespace
 //
+constexpr int UbloxNode::kResetWait;
+constexpr double UbloxNode::kPollDuration;
+constexpr float UbloxNode::kDiagnosticPeriod;
+constexpr double UbloxNode::kFixFreqTol;
+constexpr double UbloxNode::kFixFreqWindow;
+constexpr double UbloxNode::kTimeStampStatusMin;
+
+constexpr double RawDataProduct::kRtcmFreqTol;
+constexpr int RawDataProduct::kRtcmFreqWindow;
+
+constexpr double HpgRovProduct::kRtcmFreqMin;
+constexpr double HpgRovProduct::kRtcmFreqMax;
+constexpr double HpgRovProduct::kRtcmFreqTol;
+constexpr int HpgRovProduct::kRtcmFreqWindow;
+
 uint8_t ublox_node::modelFromString(const std::string& model) {
   std::string lower = model;
   std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);


### PR DESCRIPTION
I have added definitions for the constexpr static members to avoid unexpected linker issues as I got on my machine:
`/usr/bin/ld: CMakeFiles/ublox_gps_node.dir/src/node.cpp.o: in function 'ublox_node::UbloxNode::configureUblox()':
node.cpp:(.text+0x7f4b): undefined reference to 'ublox_node::UbloxNode::kResetWait'
/usr/bin/ld: catkin_ws/devel/lib/libublox_gps.so: undefined reference to 'ublox_gps::Gps::kSetBaudrateSleepMs'
collect2: error: ld returned 1 exit status
make[2]: *** [ublox/ublox_gps/CMakeFiles/ublox_gps_node.dir/build.make:139: catkin_ws/devel/lib/ublox_gps/ublox_gps] Error 1
make[1]: *** [CMakeFiles/Makefile2:11577: ublox/ublox_gps/CMakeFiles/ublox_gps_node.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
Invoking "make -j4 -l4" failed`

Please note, as of C++17 we don't need to have that "redundant" definition anymore.