### PR TITLE
TUC-ProAut: added raw data output

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ The two topics to which you should subscribe are `~fix` and `~fix_velocity`. The
 
 # Version history
 
+* **1.1.3**:
+  - Update by TUC-ProAut
+  - Added raw data output (publishing ros messages and storing to file).
+
 * **1.1.2**:
   - BUG FIX for NavSatFix messages for firmware >=7. The NavSatFix now only uses the NavPVT message time if it is valid, otherwise it uses ROS time.
   - BUG FIX for TMODE3 Fixed mode configuration. The ARP High Precision position is now configured correctly. 

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -393,6 +393,12 @@ class Gps {
   bool waitForAcknowledge(const boost::posix_time::time_duration& timeout,
                           uint8_t class_id, uint8_t msg_id);
 
+  /**
+   * @brief Set the callback function which handles raw data.
+   * @param callback the write callback which handles raw data
+   */
+  void setRawDataCallback(const Worker::Callback& callback);
+
  private:
   //! Types for ACK/NACK messages, WAIT is used when waiting for an ACK
   enum AckType {

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -33,6 +33,7 @@
 // STL
 #include <vector>
 #include <set>
+#include <fstream>
 // Boost
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -49,6 +50,7 @@
 #include <sensor_msgs/NavSatFix.h>
 #include <sensor_msgs/TimeReference.h>
 #include <sensor_msgs/Imu.h>
+#include <std_msgs/String.h>
 // Other U-Blox package includes
 #include <ublox_msgs/ublox_msgs.h>
 // Ublox GPS includes
@@ -120,6 +122,15 @@ uint16_t nav_rate;
 std::vector<uint8_t> rtcm_ids;
 //! Rates of RTCM out messages. Size must be the same as rtcm_ids
 std::vector<uint8_t> rtcm_rates;
+//! Directoy name for storing raw data
+std::string raw_data_dir_;
+//! Filename for storing raw data
+std::string raw_data_filename_;
+//!< Handle for file access
+std::ofstream raw_data_file_;
+//! Flag for publishing raw data 
+bool raw_data_flag_;
+
 
 //! Topic diagnostics for u-blox messages
 struct UbloxTopicDiagnostic {
@@ -578,6 +589,13 @@ class UbloxNode : public virtual ComponentInterface {
    * @brief Configure INF messages, call after subscribe.
    */
   void configureInf();
+
+  /**
+   * @brief Callback function which handles raw data.
+   * @param data the buffer of u-blox messages to process
+   * @param size the size of the buffer
+   */
+  void rawDataCallback(const unsigned char* data, const std::size_t size);
 
   //! The u-blox node components
   /*!

--- a/ublox_gps/include/ublox_gps/worker.h
+++ b/ublox_gps/include/ublox_gps/worker.h
@@ -49,6 +49,12 @@ class Worker {
   virtual void setCallback(const Callback& callback) = 0;
 
   /**
+   * @brief Set the callback function which handles raw data.
+   * @param callback the write callback which handles raw data
+   */
+  virtual void setRawDataCallback(const Callback& callback) = 0;
+
+  /**
    * @brief Send the data in the buffer.
    * @param data the bytes to send
    * @param size the size of the buffer

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -552,6 +552,11 @@ bool Gps::waitForAcknowledge(const boost::posix_time::time_duration& timeout,
   return result;
 }
 
+void Gps::setRawDataCallback(const Worker::Callback& callback) {
+  if (! worker_) return;
+  worker_->setRawDataCallback(callback);
+}
+
 bool Gps::setUTCtime() {
   ROS_DEBUG("Setting time to UTC time");
 

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -32,6 +32,10 @@
 #include <string>
 #include <sstream>
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <time.h>
+
 using namespace ublox_node;
 
 //
@@ -210,6 +214,9 @@ void UbloxNode::getRosParams() {
 
   // measurement period [ms]
   meas_rate = 1000 / rate_;
+
+  nh->param<std::string>("raw_data/dir", raw_data_dir_, "");
+  nh->param("raw_data/publish", raw_data_flag_, false);
 }
 
 void UbloxNode::pollMessages(const ros::TimerEvent& event) {
@@ -518,6 +525,58 @@ void UbloxNode::initializeIo() {
   } else {
     gps.initializeSerial(device_, baudrate_, uart_in_, uart_out_);
   }
+
+  if (raw_data_flag_ || (!raw_data_dir_.empty())) {
+    gps.setRawDataCallback(
+      boost::bind(&UbloxNode::rawDataCallback,this, _1, _2));
+
+    if (raw_data_flag_) {
+      ROS_INFO("Publishing raw data stream.");
+    }
+
+    if (!raw_data_dir_.empty()) {
+      struct stat stat_info;
+      if (stat(raw_data_dir_.c_str(), &stat_info ) != 0) {
+        ROS_ERROR("Can't log raw data to file. "
+          "Directory \"%s\" does not exist.", raw_data_dir_.c_str());
+
+      } else if ((stat_info.st_mode & S_IFDIR) != S_IFDIR) {
+        ROS_ERROR("Can't log raw data to file. "
+          "\"%s\" exists, but is not a directory.", raw_data_dir_.c_str());
+
+      } else {
+        if (raw_data_dir_.back() != '/') {
+          raw_data_dir_ += '/';
+        }
+
+        time_t t = time(NULL);
+        struct tm time_struct = *localtime(&t);
+
+        std::stringstream filename;
+        filename.width(4); filename.fill('0');
+          filename << time_struct.tm_year + 1900;
+          filename.width(0); filename << '_';
+        filename.width(2); filename.fill('0');
+          filename << time_struct.tm_mon  + 1;
+          filename.width(0); filename << '_';
+        filename.width(2); filename.fill('0'); filename << time_struct.tm_mday;
+          filename.width(0); filename << '_';
+        filename.width(2); filename.fill('0'); filename << time_struct.tm_hour;
+        filename.width(2); filename.fill('0'); filename << time_struct.tm_min ;
+        filename.width(0); filename << ".log";
+        raw_data_filename_ = raw_data_dir_ + filename.str();
+
+        try {
+          raw_data_file_.open(raw_data_filename_);
+          ROS_INFO("Logging raw data to file \"%s\"", 
+            raw_data_filename_.c_str());
+        } catch(const std::exception& e) {
+          ROS_ERROR("Can't log raw data to file. "
+            "Can't create file \"%s\".", raw_data_filename_.c_str());
+        }
+      }
+    }
+  }
 }
 
 void UbloxNode::initialize() {
@@ -557,6 +616,26 @@ void UbloxNode::shutdown() {
   if (gps.isInitialized()) {
     gps.close();
     ROS_INFO("Closed connection to %s.", device_.c_str());
+  }
+}
+
+void UbloxNode::rawDataCallback(const unsigned char* data,
+  const std::size_t size) {
+
+  std::string str((const char*) data, size);
+  if (raw_data_flag_) {
+    std_msgs::String msg;
+    msg.data = str;
+    ublox_node::publish(msg, "raw_data");
+  }
+
+  if (raw_data_file_.is_open()) {
+    try {
+      raw_data_file_ << str;
+      // raw_data_file_.flush();
+    } catch(const std::exception& e) {
+      ROS_WARN("Error writing to file \"%s\"", raw_data_filename_.c_str());
+    }
   }
 }
 


### PR DESCRIPTION
With our small changes it is possible to store the raw data stream to a logfile and/or to publish it as ros-messages.

logfile:
  + this is used to directly store the raw data file to disk
  + we need this feature to compare the relnav output the ublox with the solution of the rtklib
      (which we get by post-processing the logfile)
  + only the additional parameter "~/raw_data/dir" must be set to a valid path (e.g. /home/user/logging)
  + afterwards a logfile with the current date and time will be created (e.g. 2019_03_29_2033.log)

ros messages:
  + this is useful to store the raw data stream to a bagfile (as a backup for the stored logfile)
  + only the additional parameter "~/raw_data/publish" must be set to true
  + afterwards the topic "~/raw_data" will publish messages of type std_msgs/String

normal behaviour:
  + if the two parameters are not changed/set, then the node behaves as before