### PR TITLE
FIX: overflow error when assigning nsec field of message header stamp

### DIFF
--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -790,8 +790,17 @@ class UbloxFirmware7Plus : public UbloxFirmware {
     if (((m.valid & valid_time) == valid_time) &&
         (m.flags2 & m.FLAGS2_CONFIRMED_AVAILABLE)) {
       // Use NavPVT timestamp since it is valid
-      fix.header.stamp.sec = toUtcSeconds(m);
-      fix.header.stamp.nsec = m.nano;
+      // The time in nanoseconds from the NavPVT message can be between -1e9 and 1e9
+      //  The ros time uses only unsigned values, so a negative nano seconds must be
+      //  converted to a positive value
+      if (m.nano < 0) {
+        fix.header.stamp.sec = toUtcSeconds(m) - 1;
+        fix.header.stamp.nsec = (uint32_t)(m.nano + 1e9);
+      }
+      else {
+        fix.header.stamp.sec = toUtcSeconds(m);
+        fix.header.stamp.nsec = (uint32_t)(m.nano);
+      }
     } else {
       // Use ROS time since NavPVT timestamp is not valid
       fix.header.stamp = ros::Time::now();


### PR DESCRIPTION
FIX: overflow bug when the nano field of the NavPVT message (which is signed and can be negative) is assigned to the nsec value of a ros time stamp (which is unsigned)

Note: This error was discovered in a ublox M8 gps, but given the specification of the nano field as a signed value it could be for any ublox NavPVT message. For our GPS, the nano field slowly drifts in the order of 500 microseconds, and after about half an hour the value changes from positive to negative. The existing behaviour of the ublox ROS node was to report the correct value for seconds, but a value of approx 4200000000 nanoseconds which corresponds to 4.2 seconds worth of nano seconds. This is due to the 32 bit assignment of a negative number to an unsigned header.nsec 32 bit number.