### PR TITLE
Fix for corrupted diagnostics messages

### DIFF
--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -129,6 +129,9 @@ bool config_on_startup_flag_;
 struct UbloxTopicDiagnostic {
   UbloxTopicDiagnostic() {}
 
+  // Must not copy this struct (would confuse FrequencyStatusParam pointers)
+  UbloxTopicDiagnostic(const UbloxTopicDiagnostic&) = delete;
+
   /**
    * @brief Add a topic diagnostic to the diagnostic updater for
    *
@@ -181,6 +184,9 @@ struct UbloxTopicDiagnostic {
 struct FixDiagnostic {
   FixDiagnostic() {}
 
+  // Must not copy this struct (would confuse FrequencyStatusParam pointers)
+  FixDiagnostic(const FixDiagnostic&) = delete;
+
   /**
    * @brief Add a topic diagnostic to the diagnostic updater for fix topics.
    *
@@ -214,7 +220,7 @@ struct FixDiagnostic {
 };
 
 //! fix frequency diagnostic updater
-FixDiagnostic freq_diag;
+boost::shared_ptr<FixDiagnostic> freq_diag;
 
 /**
  * @brief Determine dynamic model from human-readable string.
@@ -850,7 +856,7 @@ class UbloxFirmware7Plus : public UbloxFirmware {
     // Update diagnostics
     //
     last_nav_pvt_ = m;
-    freq_diag.diagnostic->tick(fix.header.stamp);
+    freq_diag->diagnostic->tick(fix.header.stamp);
     updater->update();
   }
 
@@ -1035,7 +1041,7 @@ class RawDataProduct: public virtual ComponentInterface {
 
  private:
   //! Topic diagnostic updaters
-  std::vector<UbloxTopicDiagnostic> freq_diagnostics_;
+  std::vector<boost::shared_ptr<UbloxTopicDiagnostic> > freq_diagnostics_;
 };
 
 /**

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -334,8 +334,8 @@ void UbloxNode::initializeRosDiagnostics() {
   updater->setHardwareID("ublox");
 
   // configure diagnostic updater for frequency
-  freq_diag = FixDiagnostic(std::string("fix"), kFixFreqTol,
-                            kFixFreqWindow, kTimeStampStatusMin);
+  freq_diag.reset(new FixDiagnostic(std::string("fix"), kFixFreqTol,
+                            kFixFreqWindow, kTimeStampStatusMin));
   for(int i = 0; i < components_.size(); i++)
     components_[i]->initializeRosDiagnostics();
 }
@@ -753,7 +753,7 @@ void UbloxFirmware6::callbackNavPosLlh(const ublox_msgs::NavPOSLLH& m) {
   fixPublisher.publish(fix_);
   last_nav_pos_ = m;
   //  update diagnostics
-  freq_diag.diagnostic->tick(fix_.header.stamp);
+  freq_diag->diagnostic->tick(fix_.header.stamp);
   updater->update();
 }
 
@@ -1254,17 +1254,17 @@ void RawDataProduct::subscribe() {
 
 void RawDataProduct::initializeRosDiagnostics() {
   if (enabled["rxm_raw"])
-    freq_diagnostics_.push_back(UbloxTopicDiagnostic("rxmraw", kRtcmFreqTol,
-                                               kRtcmFreqWindow));
+    freq_diagnostics_.push_back(boost::shared_ptr<UbloxTopicDiagnostic>(
+      new UbloxTopicDiagnostic("rxmraw", kRtcmFreqTol, kRtcmFreqWindow)));
   if (enabled["rxm_sfrb"])
-    freq_diagnostics_.push_back(UbloxTopicDiagnostic("rxmsfrb", kRtcmFreqTol,
-                                               kRtcmFreqWindow));
+    freq_diagnostics_.push_back(boost::shared_ptr<UbloxTopicDiagnostic>(
+      new UbloxTopicDiagnostic("rxmsfrb", kRtcmFreqTol, kRtcmFreqWindow)));
   if (enabled["rxm_eph"])
-    freq_diagnostics_.push_back(UbloxTopicDiagnostic("rxmeph", kRtcmFreqTol,
-                                               kRtcmFreqWindow));
+    freq_diagnostics_.push_back(boost::shared_ptr<UbloxTopicDiagnostic>(
+      new UbloxTopicDiagnostic("rxmeph", kRtcmFreqTol, kRtcmFreqWindow)));
   if (enabled["rxm_alm"])
-    freq_diagnostics_.push_back(UbloxTopicDiagnostic("rxmalm", kRtcmFreqTol,
-                                               kRtcmFreqWindow));
+    freq_diagnostics_.push_back(boost::shared_ptr<UbloxTopicDiagnostic>(
+      new UbloxTopicDiagnostic("rxmalm", kRtcmFreqTol, kRtcmFreqWindow)));
 }
 
 //


### PR DESCRIPTION
This is a fix for a bug in the diagnostic messages.

The structs FixDiagnostic and UbloxTopicDiagnostic use native pointers: 
https://github.com/KumarRobotics/ublox/blob/362c67046691a916665d7916ca693305ff225bc9/ublox_gps/include/ublox_gps/node.h#L198
They also use copy constructors:
https://github.com/KumarRobotics/ublox/blob/362c67046691a916665d7916ca693305ff225bc9/ublox_gps/src/node.cpp#L337
Thus resulting in the pointer addresses beeing freed.

This PR fixes the problem. It removed the copy constructor and creates the structs in heap.