### PR TITLE
Add support for ZED-F9P new RELPOSNED message and provide heading output

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ To publish a given u-blox message to a ROS topic, set the parameter shown below 
 * `publish/nav/posllh`: Topic `~navposllh`. **Firmware <= 6 only.** For firmware 7 and above, see NavPVT
 * `publish/nav/pvt`: Topic `~navpvt`. **Firmware >= 7 only.**
 * `publish/nav/relposned`: Topic `~navrelposned`. **HPG Rover devices only**
+* `publish/nav/heading`: Topic `~navheading`. **HP Position receiver devices only.** For firmware 9 and above
 * `publish/nav/sat`: Topic `~navsat`
 * `publish/nav/sol`: Topic `~navsol`. **Firmware <= 6 only.** For firmware 7 and above, see NavPVT
 * `publish/nav/status`: Topic `~navstatus`
@@ -201,6 +202,9 @@ The two topics to which you should subscribe are `~fix` and `~fix_velocity`. The
 
 # Version history
 
+* **1.1.4**:
+  - Added messages for firmware 9: `NavRELPOSNED9`.
+  - Added option to publish `sensor_msgs/Imu` message for High Precision Position Receiver devices with firmware version >= 9 for moving base applications (For example ZED-F9P; [UBX-19009093 AppNote](https://www.u-blox.com/sites/default/files/ZED-F9P-MovingBase_AppNote_%28UBX-19009093%29.pdf)).
 * **1.1.3**:
   - Update by TUC-ProAut
   - Added raw data stream output. To publish ros messages set rosparam `raw_data_stream/publish` to true. To store to a logfile set rosparam `set raw_data_stream/dir` to the appropriated directory. This feature has nothing todo with Raw Data Products.

--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ublox_gps)
 find_package(catkin REQUIRED COMPONENTS
+  tf
   roscpp
   roscpp_serialization
   ublox_msgs
@@ -11,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS roscpp ublox_msgs ublox_serialization)
+    CATKIN_DEPENDS tf roscpp ublox_msgs ublox_serialization)
 
 # include boost
 find_package(Boost REQUIRED COMPONENTS system regex thread)

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -41,6 +41,7 @@
 #include <ros/ros.h>
 #include <ros/console.h>
 #include <ros/serialization.h>
+#include <tf/transform_datatypes.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/publisher.h>
 // ROS messages
@@ -1009,6 +1010,14 @@ class UbloxFirmware8 : public UbloxFirmware7Plus<ublox_msgs::NavPVT> {
 };
 
 /**
+ *  @brief Implements functions for firmware version 9.
+ *  For now it simply re-uses the firmware version 8 class
+ *  but allows for future expansion of functionality
+ */
+class UbloxFirmware9 : public UbloxFirmware8 {
+};
+
+/**
  * @brief Implements functions for Raw Data products.
  */
 class RawDataProduct: public virtual ComponentInterface {
@@ -1301,6 +1310,28 @@ class HpgRovProduct: public virtual ComponentInterface {
 
   //! The RTCM topic frequency diagnostic updater
   UbloxTopicDiagnostic freq_rtcm_;
+};
+
+class HpPosRecProduct: public virtual HpgRefProduct {
+ public:
+  /**
+   * @brief Subscribe to Rover messages, such as NavRELPOSNED.
+   */
+  void subscribe();
+
+ protected:
+
+  /**
+   * @brief Set the last received message and call rover diagnostic updater
+   *
+   * @details Publish received NavRELPOSNED messages if enabled
+   */
+  void callbackNavRelPosNed(const ublox_msgs::NavRELPOSNED9 &m);
+
+  sensor_msgs::Imu imu_;
+
+  //! Last relative position (used for diagnostic updater)
+  ublox_msgs::NavRELPOSNED9 last_rel_pos_;
 };
 
 /**

--- a/ublox_gps/package.xml
+++ b/ublox_gps/package.xml
@@ -18,6 +18,7 @@
   <depend>ublox_msgs</depend>
   <depend>roscpp</depend>
   <depend>roscpp_serialization</depend>
+  <depend>tf</depend>
   <depend>diagnostic_updater</depend>
 
 </package>

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.h
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.h
@@ -36,6 +36,7 @@
 #include <ublox_msgs/NavPOSECEF.h>
 #include <ublox_msgs/NavPOSLLH.h>
 #include <ublox_msgs/NavRELPOSNED.h>
+#include <ublox_msgs/NavRELPOSNED9.h>
 #include <ublox_msgs/NavSBAS.h>
 #include <ublox_msgs/NavSOL.h>
 #include <ublox_msgs/NavPVT.h>
@@ -158,6 +159,7 @@ namespace Message {
     static const uint8_t POSECEF = NavPOSECEF::MESSAGE_ID;
     static const uint8_t POSLLH = NavPOSLLH::MESSAGE_ID;
     static const uint8_t RELPOSNED = NavRELPOSNED::MESSAGE_ID;
+    static const uint8_t RELPOSNED9 = NavRELPOSNED9::MESSAGE_ID;
     static const uint8_t SBAS = NavSBAS::MESSAGE_ID;
     static const uint8_t SOL = NavSOL::MESSAGE_ID;
     static const uint8_t PVT = NavPVT::MESSAGE_ID;

--- a/ublox_msgs/msg/NavRELPOSNED9.msg
+++ b/ublox_msgs/msg/NavRELPOSNED9.msg
@@ -1,0 +1,106 @@
+# NAV-RELPOSNED (0x01 0x3C)
+# Relative Positioning Information in NED frame
+#
+# The NED frame is defined as the local topological system at the reference
+# station. The relative position vector components in this message, along with
+# their associated accuracies, are given in that local topological system
+# This message contains the relative position vector from the Reference Station
+# to the Rover, including accuracy figures, in the local topological system
+# defined at the reference station
+#
+# Supported on:
+#  - u-blox 9 from protocol version 27.11 (only with High Precision GNSS products)
+#
+
+uint8 CLASS_ID = 1
+uint8 MESSAGE_ID = 60
+
+uint8 version                     # Message version (0x00 for this version)
+uint8 reserved1                   # Reserved
+uint16 refStationId               # Reference Station ID. Must be in the range
+                                  # 0..4095
+uint32 iTow                       # GPS time of week of the navigation epoch
+                                  # [ms]
+
+int32 relPosN                     # North component of relative position vector
+                                  # [cm]
+int32 relPosE                     # East component of relative position vector
+                                  # [cm]
+int32 relPosD                     # Down component of relative position vector
+                                  # [cm]
+int32 relPosLength                # Length of the relative position vector
+                                  # [cm]
+int32 relPosHeading               # Heading of the relative position vector
+                                  # [1e-5 deg]
+uint8[4] reserved2                # Reserved
+int8 relPosHPN                    # High-precision North component of relative
+                                  # position vector. [0.1 mm]
+                                  # Must be in the range -99 to +99.
+                                  # The full North component of the relative
+                                  # position vector, in units of cm, is given by
+                                  # relPosN + (relPosHPN * 1e-2)
+int8 relPosHPE                    # High-precision East component of relative
+                                  # position vector. [0.1 mm]
+                                  # Must be in the range -99 to +99.
+                                  # The full East component of the relative
+                                  # position vector, in units of cm, is given by
+                                  # relPosE + (relPosHPE * 1e-2)
+int8 relPosHPD                    # High-precision Down component of relative
+                                  # position vector. [0.1 mm]
+                                  # Must be in the range -99 to +99.
+                                  # The full Down component of the relative
+                                  # position vector, in units of cm, is given by
+                                  # relPosD + (relPosHPD * 1e-2)
+int8 relPosHPLength               # High-precision component of the length of
+                                  # the relative position vector.
+                                  # Must be in the range -99 to +99.
+                                  # The full length of the relative position
+                                  # vector, in units of cm, is given by
+                                  # relPosLength + (relPosHPLength * 1e-2)
+
+uint32 accN                       # Accuracy of relative position North
+                                  # component [0.1 mm]
+uint32 accE                       # Accuracy of relative position East component
+                                  # [0.1 mm]
+uint32 accD                       # Accuracy of relative position Down component
+                                  # [0.1 mm]
+uint32 accLength                  # Accuracy of length of the relative position
+                                  # vector [0.1 mm]
+uint32 accHeading                 # Accuracy of heading of the relative position
+                                  # vector [0.1 mm]
+
+uint8[4] reserved3                # Reserved
+
+uint32 flags
+uint32 FLAGS_GNSS_FIX_OK = 1      # A valid fix (i.e within DOP & accuracy
+                                  # masks)
+uint32 FLAGS_DIFF_SOLN = 2        # Set if differential corrections were applied
+uint32 FLAGS_REL_POS_VALID = 4    # Set if relative position components and
+                                  # accuracies are valid
+uint32 FLAGS_CARR_SOLN_MASK = 24  # Carrier phase range solution status:
+uint32 FLAGS_CARR_SOLN_NONE = 0     # No carrier phase range solution
+uint32 FLAGS_CARR_SOLN_FLOAT = 8    # Float solution. No fixed integer carrier
+                                    # phase measurements have been used to
+                                    # calculate the solution
+uint32 FLAGS_CARR_SOLN_FIXED = 16   # Fixed solution. One or more fixed
+                                    # integer carrier phase range measurements
+                                    # have been used to calculate the solution
+uint32 FLAGS_IS_MOVING = 32       # if the receiver is operating in moving
+                                  # baseline mode (not supported in protocol
+                                  # versions less than 20.3)
+uint32 FLAGS_REF_POS_MISS = 64    # Set if extrapolated reference position was
+                                  # used to compute moving baseline solution
+                                  # this epoch (not supported in protocol
+                                  # versions less than 20.3)
+uint32 FLAGS_REF_OBS_MISS = 128   # Set if extrapolated reference observations
+                                  # were used to compute moving baseline
+                                  # solution this epoch (not supported in
+                                  # protocol versions less than 20.3)
+uint32 FLAGS_REL_POS_HEAD_VALID = 256   # Set if extrapolated reference observations
+                                        # were used to compute moving baseline
+                                        # solution this epoch (not supported in
+                                        # protocol versions less than 20.3)
+uint32 FLAGS_REL_POS_NORM = 512   # Set if extrapolated reference observations
+                                  # were used to compute moving baseline
+                                  # solution this epoch (not supported in
+                                  # protocol versions less than 20.3)

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -47,6 +47,10 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV,
                       ublox_msgs::Message::NAV::RELPOSNED, 
                       ublox_msgs, 
                       NavRELPOSNED);
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV,
+                      ublox_msgs::Message::NAV::RELPOSNED9,
+                      ublox_msgs,
+                      NavRELPOSNED9);
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::SBAS, 
                       ublox_msgs, NavSBAS);
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::SOL, 


### PR DESCRIPTION
We are using the ublox ZED-F9P chip in a couple of applications.
This PR adds support for this chip.
The outputted `UBX-NAV-RELPOSNED` message changed in the firmware so this is added as a new message. Furthermore, this chip supports outputting heading information in a moving-base application, so it is configurable to publish a `sensor_msgs/Imu` message as well for use in robot localization.