### PR TITLE
Fix heading output to comply with REP-103

### DIFF
--- a/ublox_msgs/msg/NavRELPOSNED9.msg
+++ b/ublox_msgs/msg/NavRELPOSNED9.msg
@@ -67,7 +67,7 @@ uint32 accD                       # Accuracy of relative position Down component
 uint32 accLength                  # Accuracy of length of the relative position
                                   # vector [0.1 mm]
 uint32 accHeading                 # Accuracy of heading of the relative position
-                                  # vector [0.1 mm]
+                                  # vector [1e-5 deg]
 
 uint8[4] reserved3                # Reserved
 


### PR DESCRIPTION
Unfortunately we discovered some small errors in the field with the ZED-F9P heading information. uBlox is outputting in NED by default, while ROS uses ENU by convention. To comply with REP-103 I created this PR.

Furthermore when there is no valid heading information, we now put the covariance also high, instead of taking a value of 0.