### PR TITLE
Fix unit in covariance calculation

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -1751,7 +1751,7 @@ void HpPosRecProduct::callbackNavRelPosNed(const ublox_msgs::NavRELPOSNED9 &m) {
     // When heading is reported to be valid, use accuracy reported in 1e-5 deg units
     if (m.flags & ublox_msgs::NavRELPOSNED9::FLAGS_REL_POS_HEAD_VALID)
     {
-      imu_.orientation_covariance[8] = pow(m.accHeading / 10000.0, 2);
+      imu_.orientation_covariance[8] = pow(m.accHeading * 1e-5 / 180.0 * M_PI, 2);
     }
 
     imu_pub.publish(imu_);


### PR DESCRIPTION
While looking closely at the logdata we made in a couple of runs with two ZED-F9Ps, we noticed a small error in the covariance calculation...