### PR TITLE
Added configuration for UART2

### DIFF
--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -102,11 +102,8 @@ class Gps {
    * @brief Initialize the Serial I/O port.
    * @param port the device port address
    * @param baudrate the desired baud rate of the port
-   * @param uart_in the UART In protocol, see CfgPRT for options
-   * @param uart_out the UART Out protocol, see CfgPRT for options
    */
-  void initializeSerial(std::string port, unsigned int baudrate,
-                        uint16_t uart_in, uint16_t uart_out);
+  void initializeSerial(std::string port, unsigned int baudrate);
 
   /**
    * @brief Reset the Serial I/O port after u-blox reset.
@@ -155,14 +152,11 @@ class Gps {
   bool clearBbr();
 
   /**
-   * @brief Configure the UART1 Port.
-   * @param baudrate the baudrate of the port
-   * @param in_proto_mask the in protocol mask, see CfgPRT message
-   * @param out_proto_mask the out protocol mask, see CfgPRT message
+   * @brief Configure the UART Ports.
+   * @param config CfgPRT message containing port settings
    * @return true on ACK, false on other conditions.
    */
-  bool configUart1(unsigned int baudrate, uint16_t in_proto_mask,
-                   uint16_t out_proto_mask);
+  bool configUart(const ublox_msgs::CfgPRT& config);
 
   /**
    * @brief Disable the UART Port. Sets in/out protocol masks to 0. Does not
@@ -171,7 +165,7 @@ class Gps {
    * configuration parameters
    * @return true on ACK, false on other conditions.
    */
-  bool disableUart1(ublox_msgs::CfgPRT& prev_cfg);
+  bool disableUart(ublox_msgs::CfgPRT& prev_cfg);
 
   /**
    * @brief Configure the USB Port.

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -610,12 +610,10 @@ class UbloxNode : public virtual ComponentInterface {
   uint8_t dmodel_;
   //! Set from fix mode string
   uint8_t fmode_;
-  //! UART1 baudrate
-  uint32_t baudrate_;
-  //! UART in protocol (see CfgPRT message for constants)
-  uint16_t uart_in_;
-  //! UART out protocol (see CfgPRT message for constants)
-  uint16_t uart_out_;
+  //! Serial(USB) baudrate
+  uint32_t serial_baudrate_;
+  //! UART configuration
+  ublox_msgs::CfgPRT uart1_, uart2_;
   //! USB TX Ready Pin configuration (see CfgPRT message for constants)
   uint16_t usb_tx_;
   //! Whether to configure the USB port

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -581,7 +581,6 @@ void UbloxNode::initialize() {
 
   if (configureUblox()) {
     ROS_INFO("U-Blox configured successfully.");
-
     // Subscribe to all U-Blox messages
     subscribe();
     // Configure INF messages (needs INF params, call after subscribing)
@@ -1150,7 +1149,7 @@ bool UbloxFirmware8::configureUblox() {
   // Then, check the configuration for each GNSS. If it is different, change it.
   bool correct = true;
   for (int i = 0; i < cfg_gnss.blocks.size(); i++) {
-    const ublox_msgs::CfgGNSS_Block& block = cfg_gnss.blocks[i];
+    ublox_msgs::CfgGNSS_Block block = cfg_gnss.blocks[i];
     if (block.gnssId == block.GNSS_ID_GPS
         && enable_gps_ != (block.flags & block.FLAGS_ENABLE)) {
       correct = false;
@@ -1335,7 +1334,7 @@ void AdrUdrProduct::subscribe() {
     // also publish sensor_msgs::Imu
     gps.subscribe<ublox_msgs::EsfMEAS>(boost::bind(
       &AdrUdrProduct::callbackEsfMEAS, this, _1), kSubscribeRate);
-
+ 
   // Subscribe to ESF Raw messages
   nh->param("publish/esf/raw", enabled["esf_raw"], enabled["esf"]);
   if (enabled["esf_raw"])
@@ -1357,32 +1356,32 @@ void AdrUdrProduct::subscribe() {
 
 void AdrUdrProduct::callbackEsfMEAS(const ublox_msgs::EsfMEAS &m) {
   if (enabled["esf_meas"]) {
-    static ros::Publisher imu_pub =
+    static ros::Publisher imu_pub = 
 	nh->advertise<sensor_msgs::Imu>("imu_meas", kROSQueueSize);
     static ros::Publisher time_ref_pub =
 	nh->advertise<sensor_msgs::TimeReference>("interrupt_time", kROSQueueSize);
-
+    
     imu_.header.stamp = ros::Time::now();
     imu_.header.frame_id = frame_id;
-
+    
     float deg_per_sec = pow(2, -12);
     float m_per_sec_sq = pow(2, -10);
     float deg_c = 1e-2;
-
+     
     std::vector<unsigned int> imu_data = m.data;
     for (int i=0; i < imu_data.size(); i++){
       unsigned int data_type = imu_data[i] >> 24; //grab the last six bits of data
       double data_sign = (imu_data[i] & (1 << 23)); //grab the sign (+/-) of the rest of the data
       unsigned int data_value = imu_data[i] & 0x7FFFFF; //grab the rest of the data...should be 23 bits
-
+      
       if (data_sign == 0) {
         data_sign = -1;
       } else {
         data_sign = 1;
       }
-
+           
       //ROS_INFO("data sign (+/-): %f", data_sign); //either 1 or -1....set by bit 23 in the data bitarray
-
+  
       imu_.orientation_covariance[0] = -1;
       imu_.linear_acceleration_covariance[0] = -1;
       imu_.angular_velocity_covariance[0] = -1;
@@ -1426,31 +1425,31 @@ void AdrUdrProduct::callbackEsfMEAS(const ublox_msgs::EsfMEAS &m) {
           imu_.linear_acceleration.z = data_sign * data_value * m_per_sec_sq;
         }
       } else if (data_type == 12) {
-        //ROS_INFO("Temperature in celsius: %f", data_value * deg_c);
+        //ROS_INFO("Temperature in celsius: %f", data_value * deg_c); 
       } else {
         ROS_INFO("data_type: %u", data_type);
         ROS_INFO("data_value: %u", data_value);
-      }
-
+      } 
+     
       // create time ref message and put in the data
       //t_ref_.header.seq = m.risingEdgeCount;
       //t_ref_.header.stamp = ros::Time::now();
       //t_ref_.header.frame_id = frame_id;
 
-      //t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR);
-
+      //t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR); 
+    
       //std::ostringstream src;
-      //src << "TIM" << int(m.ch);
+      //src << "TIM" << int(m.ch); 
       //t_ref_.source = src.str();
 
       t_ref_.header.stamp = ros::Time::now(); // create a new timestamp
       t_ref_.header.frame_id = frame_id;
-
+   
       time_ref_pub.publish(t_ref_);
       imu_pub.publish(imu_);
     }
   }
-
+  
   updater->force_update();
 }
 //
@@ -1789,9 +1788,9 @@ void TimProduct::getRosParams() {
 bool TimProduct::configureUblox() {
   uint8_t r = 1;
   // Configure the reciever
-  if(!gps.setUTCtime())
+  if(!gps.setUTCtime()) 
     throw std::runtime_error(std::string("Failed to Configure TIM Product to UTC Time"));
-
+ 
   if(!gps.setTimtm2(r))
     throw std::runtime_error(std::string("Failed to Configure TIM Product"));
 
@@ -1806,15 +1805,15 @@ void TimProduct::subscribe() {
 
   gps.subscribe<ublox_msgs::TimTM2>(boost::bind(
     &TimProduct::callbackTimTM2, this, _1), kSubscribeRate);
-
+	
   ROS_INFO("Subscribed to TIM-TM2 messages on topic tim/tm2");
-
+	
   // Subscribe to SFRBX messages
   nh->param("publish/rxm/sfrb", enabled["rxm_sfrb"], enabled["rxm"]);
   if (enabled["rxm_sfrb"])
     gps.subscribe<ublox_msgs::RxmSFRBX>(boost::bind(
         publish<ublox_msgs::RxmSFRBX>, _1, "rxmsfrb"), kSubscribeRate);
-
+	
    // Subscribe to RawX messages
    nh->param("publish/rxm/raw", enabled["rxm_raw"], enabled["rxm"]);
    if (enabled["rxm_raw"])
@@ -1823,31 +1822,31 @@ void TimProduct::subscribe() {
 }
 
 void TimProduct::callbackTimTM2(const ublox_msgs::TimTM2 &m) {
-
+  
   if (enabled["tim_tm2"]) {
     static ros::Publisher publisher =
     	nh->advertise<ublox_msgs::TimTM2>("timtm2", kROSQueueSize);
     static ros::Publisher time_ref_pub =
 	nh->advertise<sensor_msgs::TimeReference>("interrupt_time", kROSQueueSize);
-
+    
     // create time ref message and put in the data
     t_ref_.header.seq = m.risingEdgeCount;
     t_ref_.header.stamp = ros::Time::now();
     t_ref_.header.frame_id = frame_id;
 
-    t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR);
-
+    t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR); 
+    
     std::ostringstream src;
-    src << "TIM" << int(m.ch);
+    src << "TIM" << int(m.ch); 
     t_ref_.source = src.str();
 
     t_ref_.header.stamp = ros::Time::now(); // create a new timestamp
     t_ref_.header.frame_id = frame_id;
-
+  
     publisher.publish(m);
     time_ref_pub.publish(t_ref_);
   }
-
+  
   updater->force_update();
 }
 

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -140,11 +140,24 @@ void UbloxNode::getRosParams() {
   getRosUint("save/device", save_.deviceMask, 0);
 
   // UART 1 params
-  getRosUint("uart1/baudrate", baudrate_, 9600);
-  getRosUint("uart1/in", uart_in_, ublox_msgs::CfgPRT::PROTO_UBX
+  uart1_.portID = 1;
+  getRosUint("uart1/baudrate", uart1_.baudRate, 9600);
+  getRosUint("uart1/in", uart1_.inProtoMask, ublox_msgs::CfgPRT::PROTO_UBX
                                     | ublox_msgs::CfgPRT::PROTO_NMEA
                                     | ublox_msgs::CfgPRT::PROTO_RTCM);
-  getRosUint("uart1/out", uart_out_, ublox_msgs::CfgPRT::PROTO_UBX);
+  getRosUint("uart1/out", uart1_.outProtoMask, ublox_msgs::CfgPRT::PROTO_UBX);
+
+  // UART 2 params
+  uart2_.portID = 2;
+  getRosUint("uart2/baudrate", uart2_.baudRate, 9600);
+  getRosUint("uart2/in", uart2_.inProtoMask, ublox_msgs::CfgPRT::PROTO_UBX
+                                    | ublox_msgs::CfgPRT::PROTO_NMEA
+                                    | ublox_msgs::CfgPRT::PROTO_RTCM);
+  getRosUint("uart2/out", uart2_.outProtoMask, ublox_msgs::CfgPRT::PROTO_UBX);
+
+  // Serial over USB
+  getRosUint("baudrate", serial_baudrate_, 38400);
+
   // USB params
   set_usb_ = false;
   if (nh->hasParam("usb/in") || nh->hasParam("usb/out")) {
@@ -222,7 +235,7 @@ void UbloxNode::getRosParams() {
   // activate/deactivate any config
   nh->param("config_on_startup", config_on_startup_flag_, true);
 
-  // raw data stream logging 
+  // raw data stream logging
   rawDataStreamPa_.getRosParams();
 }
 
@@ -503,7 +516,7 @@ void UbloxNode::configureInf() {
   msg.blocks.push_back(block);
 
   // IF NMEA is enabled
-  if (uart_in_ & ublox_msgs::CfgPRT::PROTO_NMEA) {
+  if (uart1_.inProtoMask & ublox_msgs::CfgPRT::PROTO_NMEA) {
     ublox_msgs::CfgINF_Block block;
     block.protocolID = block.PROTOCOL_ID_NMEA;
     // Enable desired INF messages on each NMEA port
@@ -534,7 +547,12 @@ void UbloxNode::initializeIo() {
       throw std::runtime_error("Protocol '" + proto + "' is unsupported");
     }
   } else {
-    gps.initializeSerial(device_, baudrate_, uart_in_, uart_out_);
+    gps.initializeSerial(device_, serial_baudrate_);
+  }
+
+  if (config_on_startup_flag_) {
+      gps.configUart(uart1_);
+      gps.configUart(uart2_);
   }
 
   // raw data stream logging
@@ -563,6 +581,7 @@ void UbloxNode::initialize() {
 
   if (configureUblox()) {
     ROS_INFO("U-Blox configured successfully.");
+
     // Subscribe to all U-Blox messages
     subscribe();
     // Configure INF messages (needs INF params, call after subscribing)
@@ -1131,7 +1150,7 @@ bool UbloxFirmware8::configureUblox() {
   // Then, check the configuration for each GNSS. If it is different, change it.
   bool correct = true;
   for (int i = 0; i < cfg_gnss.blocks.size(); i++) {
-    ublox_msgs::CfgGNSS_Block block = cfg_gnss.blocks[i];
+    const ublox_msgs::CfgGNSS_Block& block = cfg_gnss.blocks[i];
     if (block.gnssId == block.GNSS_ID_GPS
         && enable_gps_ != (block.flags & block.FLAGS_ENABLE)) {
       correct = false;
@@ -1316,7 +1335,7 @@ void AdrUdrProduct::subscribe() {
     // also publish sensor_msgs::Imu
     gps.subscribe<ublox_msgs::EsfMEAS>(boost::bind(
       &AdrUdrProduct::callbackEsfMEAS, this, _1), kSubscribeRate);
- 
+
   // Subscribe to ESF Raw messages
   nh->param("publish/esf/raw", enabled["esf_raw"], enabled["esf"]);
   if (enabled["esf_raw"])
@@ -1338,32 +1357,32 @@ void AdrUdrProduct::subscribe() {
 
 void AdrUdrProduct::callbackEsfMEAS(const ublox_msgs::EsfMEAS &m) {
   if (enabled["esf_meas"]) {
-    static ros::Publisher imu_pub = 
+    static ros::Publisher imu_pub =
 	nh->advertise<sensor_msgs::Imu>("imu_meas", kROSQueueSize);
     static ros::Publisher time_ref_pub =
 	nh->advertise<sensor_msgs::TimeReference>("interrupt_time", kROSQueueSize);
-    
+
     imu_.header.stamp = ros::Time::now();
     imu_.header.frame_id = frame_id;
-    
+
     float deg_per_sec = pow(2, -12);
     float m_per_sec_sq = pow(2, -10);
     float deg_c = 1e-2;
-     
+
     std::vector<unsigned int> imu_data = m.data;
     for (int i=0; i < imu_data.size(); i++){
       unsigned int data_type = imu_data[i] >> 24; //grab the last six bits of data
       double data_sign = (imu_data[i] & (1 << 23)); //grab the sign (+/-) of the rest of the data
       unsigned int data_value = imu_data[i] & 0x7FFFFF; //grab the rest of the data...should be 23 bits
-      
+
       if (data_sign == 0) {
         data_sign = -1;
       } else {
         data_sign = 1;
       }
-           
+
       //ROS_INFO("data sign (+/-): %f", data_sign); //either 1 or -1....set by bit 23 in the data bitarray
-  
+
       imu_.orientation_covariance[0] = -1;
       imu_.linear_acceleration_covariance[0] = -1;
       imu_.angular_velocity_covariance[0] = -1;
@@ -1407,31 +1426,31 @@ void AdrUdrProduct::callbackEsfMEAS(const ublox_msgs::EsfMEAS &m) {
           imu_.linear_acceleration.z = data_sign * data_value * m_per_sec_sq;
         }
       } else if (data_type == 12) {
-        //ROS_INFO("Temperature in celsius: %f", data_value * deg_c); 
+        //ROS_INFO("Temperature in celsius: %f", data_value * deg_c);
       } else {
         ROS_INFO("data_type: %u", data_type);
         ROS_INFO("data_value: %u", data_value);
-      } 
-     
+      }
+
       // create time ref message and put in the data
       //t_ref_.header.seq = m.risingEdgeCount;
       //t_ref_.header.stamp = ros::Time::now();
       //t_ref_.header.frame_id = frame_id;
 
-      //t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR); 
-    
+      //t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR);
+
       //std::ostringstream src;
-      //src << "TIM" << int(m.ch); 
+      //src << "TIM" << int(m.ch);
       //t_ref_.source = src.str();
 
       t_ref_.header.stamp = ros::Time::now(); // create a new timestamp
       t_ref_.header.frame_id = frame_id;
-   
+
       time_ref_pub.publish(t_ref_);
       imu_pub.publish(imu_);
     }
   }
-  
+
   updater->force_update();
 }
 //
@@ -1770,9 +1789,9 @@ void TimProduct::getRosParams() {
 bool TimProduct::configureUblox() {
   uint8_t r = 1;
   // Configure the reciever
-  if(!gps.setUTCtime()) 
+  if(!gps.setUTCtime())
     throw std::runtime_error(std::string("Failed to Configure TIM Product to UTC Time"));
- 
+
   if(!gps.setTimtm2(r))
     throw std::runtime_error(std::string("Failed to Configure TIM Product"));
 
@@ -1787,15 +1806,15 @@ void TimProduct::subscribe() {
 
   gps.subscribe<ublox_msgs::TimTM2>(boost::bind(
     &TimProduct::callbackTimTM2, this, _1), kSubscribeRate);
-	
+
   ROS_INFO("Subscribed to TIM-TM2 messages on topic tim/tm2");
-	
+
   // Subscribe to SFRBX messages
   nh->param("publish/rxm/sfrb", enabled["rxm_sfrb"], enabled["rxm"]);
   if (enabled["rxm_sfrb"])
     gps.subscribe<ublox_msgs::RxmSFRBX>(boost::bind(
         publish<ublox_msgs::RxmSFRBX>, _1, "rxmsfrb"), kSubscribeRate);
-	
+
    // Subscribe to RawX messages
    nh->param("publish/rxm/raw", enabled["rxm_raw"], enabled["rxm"]);
    if (enabled["rxm_raw"])
@@ -1804,31 +1823,31 @@ void TimProduct::subscribe() {
 }
 
 void TimProduct::callbackTimTM2(const ublox_msgs::TimTM2 &m) {
-  
+
   if (enabled["tim_tm2"]) {
     static ros::Publisher publisher =
     	nh->advertise<ublox_msgs::TimTM2>("timtm2", kROSQueueSize);
     static ros::Publisher time_ref_pub =
 	nh->advertise<sensor_msgs::TimeReference>("interrupt_time", kROSQueueSize);
-    
+
     // create time ref message and put in the data
     t_ref_.header.seq = m.risingEdgeCount;
     t_ref_.header.stamp = ros::Time::now();
     t_ref_.header.frame_id = frame_id;
 
-    t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR); 
-    
+    t_ref_.time_ref = ros::Time((m.wnR * 604800 + m.towMsR / 1000), (m.towMsR % 1000) * 1000000 + m.towSubMsR);
+
     std::ostringstream src;
-    src << "TIM" << int(m.ch); 
+    src << "TIM" << int(m.ch);
     t_ref_.source = src.str();
 
     t_ref_.header.stamp = ros::Time::now(); // create a new timestamp
     t_ref_.header.frame_id = frame_id;
-  
+
     publisher.publish(m);
     time_ref_pub.publish(t_ref_);
   }
-  
+
   updater->force_update();
 }
 


### PR DESCRIPTION
Devices that use the F9P use UART2 for RTCM comms, like the Ardusimple simpleRTK2B. This PR does two things:

1. Adds the ability to configure UART2 and UART1 independently. Use the same yaml config syntax for uart2.
2. Separates UART1 baudrate from host/device baudrate. Not sure why they were tied?

Feedback appreciated.