### PR TITLE
fix signs of sensor_msgs::Imu output

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -1350,73 +1350,39 @@ void AdrUdrProduct::callbackEsfMEAS(const ublox_msgs::EsfMEAS &m) {
     imu_.header.stamp = ros::Time::now();
     imu_.header.frame_id = frame_id;
     
-    float deg_per_sec = pow(2, -12);
-    float m_per_sec_sq = pow(2, -10);
-    float deg_c = 1e-2;
+    static const float deg_per_sec = pow(2, -12);
+    static const float m_per_sec_sq = pow(2, -10);
+    static const float deg_c = 1e-2;
      
-    std::vector<unsigned int> imu_data = m.data;
+    std::vector<uint32_t> imu_data = m.data;
     for (int i=0; i < imu_data.size(); i++){
       unsigned int data_type = imu_data[i] >> 24; //grab the last six bits of data
-      double data_sign = (imu_data[i] & (1 << 23)); //grab the sign (+/-) of the rest of the data
-      unsigned int data_value = imu_data[i] & 0x7FFFFF; //grab the rest of the data...should be 23 bits
-      
-      if (data_sign == 0) {
-        data_sign = -1;
-      } else {
-        data_sign = 1;
-      }
-           
-      //ROS_INFO("data sign (+/-): %f", data_sign); //either 1 or -1....set by bit 23 in the data bitarray
-  
+      int32_t data_value = static_cast<int32_t>(imu_data[i] << 8); //shift to extend sign from 24 to 32 bit integer
+      data_value >>= 8;
+
       imu_.orientation_covariance[0] = -1;
       imu_.linear_acceleration_covariance[0] = -1;
       imu_.angular_velocity_covariance[0] = -1;
 
       if (data_type == 14) {
-        if (data_sign == 1) {
-	  imu_.angular_velocity.x = 2048 - data_value * deg_per_sec;
-        } else {
-          imu_.angular_velocity.x = data_sign * data_value * deg_per_sec;
-        }
+          imu_.angular_velocity.x = data_value * deg_per_sec;
       } else if (data_type == 16) {
-        //ROS_INFO("data_sign: %f", data_sign);
-        //ROS_INFO("data_value: %u", data_value * m);
-        if (data_sign == 1) {
-	  imu_.linear_acceleration.x = 8191 - data_value * m_per_sec_sq;
-        } else {
-          imu_.linear_acceleration.x = data_sign * data_value * m_per_sec_sq;
-        }
+          imu_.linear_acceleration.x = data_value * m_per_sec_sq;
       } else if (data_type == 13) {
-        if (data_sign == 1) {
-	  imu_.angular_velocity.y = 2048 - data_value * deg_per_sec;
-        } else {
-          imu_.angular_velocity.y = data_sign * data_value * deg_per_sec;
-        }
+          imu_.angular_velocity.y = data_value * deg_per_sec;
       } else if (data_type == 17) {
-        if (data_sign == 1) {
-	  imu_.linear_acceleration.y = 8191 - data_value * m_per_sec_sq;
-        } else {
-          imu_.linear_acceleration.y = data_sign * data_value * m_per_sec_sq;
-        }
+          imu_.linear_acceleration.y = data_value * m_per_sec_sq;
       } else if (data_type == 5) {
-        if (data_sign == 1) {
-	  imu_.angular_velocity.z = 2048 - data_value * deg_per_sec;
-        } else {
-          imu_.angular_velocity.z = data_sign * data_value * deg_per_sec;
-        }
+          imu_.angular_velocity.z = data_value * deg_per_sec;
       } else if (data_type == 18) {
-        if (data_sign == 1) {
-	  imu_.linear_acceleration.z = 8191 - data_value * m_per_sec_sq;
-        } else {
-          imu_.linear_acceleration.z = data_sign * data_value * m_per_sec_sq;
-        }
+          imu_.linear_acceleration.z = data_value * m_per_sec_sq;
       } else if (data_type == 12) {
         //ROS_INFO("Temperature in celsius: %f", data_value * deg_c); 
       } else {
         ROS_INFO("data_type: %u", data_type);
         ROS_INFO("data_value: %u", data_value);
-      } 
-     
+      }
+
       // create time ref message and put in the data
       //t_ref_.header.seq = m.risingEdgeCount;
       //t_ref_.header.stamp = ros::Time::now();


### PR DESCRIPTION
According to https://www.ros.org/reps/rep-0145.html:

> When the device is at rest, the vector will represent the specific force solely due to gravity. I.e. if the body z axis points upwards, its z axis should indicate +g. This data must be in m/s^2.

Raw data from u-blox (checked with M8U) reports -g when device's z-axis points upwards.