### PR TITLE
fixed CfgNAVX5 message generation for protocol version >= 18

### DIFF
--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -282,7 +282,7 @@ class Gps {
    * @note This is part of the expert settings. It is recommended you check
    * the ublox manual first.
    */
-  bool setPpp(bool enable);
+  bool setPpp(bool enable, float protocol_version);
 
   /**
    * @brief Set the DGNSS mode (see CfgDGNSS message for details).
@@ -296,7 +296,7 @@ class Gps {
    * @param enable If true, enable ADR.
    * @return true on ACK, false on other conditions.
    */
-  bool setUseAdr(bool enable);
+  bool setUseAdr(bool enable, float protocol_version);
 
   /**
    * @brief Configure the U-Blox to UTC time 

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -1059,6 +1059,8 @@ class RawDataProduct: public virtual ComponentInterface {
  */
 class AdrUdrProduct: public virtual ComponentInterface {
  public:
+  AdrUdrProduct(float protocol_version);
+  
   /**
    * @brief Get the ADR/UDR parameters.
    *
@@ -1092,7 +1094,8 @@ class AdrUdrProduct: public virtual ComponentInterface {
 
  protected:
   //! Whether or not to enable dead reckoning
-  bool use_adr_;
+  bool use_adr_;  
+  float protocol_version_;
 
    
   sensor_msgs::Imu imu_;

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -499,11 +499,13 @@ bool Gps::setDeadReckonLimit(uint8_t limit) {
   return configure(msg);
 }
 
-bool Gps::setPpp(bool enable) {
+bool Gps::setPpp(bool enable, float protocol_version) {
   ROS_DEBUG("%s PPP", (enable ? "Enabling" : "Disabling"));
 
   ublox_msgs::CfgNAVX5 msg;
   msg.usePPP = enable;
+  if(protocol_version >= 18)
+    msg.version = 2;
   msg.mask1 = ublox_msgs::CfgNAVX5::MASK1_PPP;
   return configure(msg);
 }
@@ -515,11 +517,14 @@ bool Gps::setDgnss(uint8_t mode) {
   return configure(cfg);
 }
 
-bool Gps::setUseAdr(bool enable) {
+bool Gps::setUseAdr(bool enable, float protocol_version) {
   ROS_DEBUG("%s ADR/UDR", (enable ? "Enabling" : "Disabling"));
 
   ublox_msgs::CfgNAVX5 msg;
   msg.useAdr = enable;
+  
+  if(protocol_version >= 18)
+    msg.version = 2;
   msg.mask2 = ublox_msgs::CfgNAVX5::MASK2_ADR;
   return configure(msg);
 }

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -120,7 +120,7 @@ void UbloxNode::addProductInterface(std::string product_category,
     components_.push_back(ComponentPtr(new TimProduct));
   else if (product_category.compare("ADR") == 0 ||
            product_category.compare("UDR") == 0)
-    components_.push_back(ComponentPtr(new AdrUdrProduct));
+    components_.push_back(ComponentPtr(new AdrUdrProduct(protocol_version_)));
   else if (product_category.compare("FTS") == 0)
     components_.push_back(ComponentPtr(new FtsProduct));
   else if(product_category.compare("SPG") != 0)
@@ -452,7 +452,7 @@ bool UbloxNode::configureUblox() {
                                   " SBAS.");
         }
       }
-      if (!gps.setPpp(enable_ppp_))
+      if (!gps.setPpp(enable_ppp_, protocol_version_))
         throw std::runtime_error(std::string("Failed to ") +
                                 ((enable_ppp_) ? "enable" : "disable")
                                 + " PPP.");
@@ -1275,6 +1275,10 @@ void RawDataProduct::initializeRosDiagnostics() {
       new UbloxTopicDiagnostic("rxmalm", kRtcmFreqTol, kRtcmFreqWindow)));
 }
 
+AdrUdrProduct::AdrUdrProduct(float protocol_version)
+    : protocol_version_(protocol_version)
+{}
+
 //
 // u-blox ADR devices, partially implemented
 //
@@ -1287,7 +1291,7 @@ void AdrUdrProduct::getRosParams() {
 }
 
 bool AdrUdrProduct::configureUblox() {
-  if(!gps.setUseAdr(use_adr_))
+  if(!gps.setUseAdr(use_adr_, protocol_version_))
     throw std::runtime_error(std::string("Failed to ")
                              + (use_adr_ ? "enable" : "disable") + "use_adr");
   return true;


### PR DESCRIPTION
According specification, version number in CfgNAVX5 must be set to 2 for protocol version >= 18 