### PR TITLE
Bump CMake minimum version to 3.0.2

### DIFF
--- a/ublox/CMakeLists.txt
+++ b/ublox/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ublox)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ublox_gps)
 find_package(catkin REQUIRED COMPONENTS
   tf

--- a/ublox_msgs/CMakeLists.txt
+++ b/ublox_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ublox_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation ublox_serialization std_msgs sensor_msgs)

--- a/ublox_serialization/CMakeLists.txt
+++ b/ublox_serialization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(ublox_serialization)
 


### PR DESCRIPTION
Bump CMake minimum version according to ROS Noetic Migration Guide https://wiki.ros.org/noetic/Migration