### PR TITLE
Add zed-f9p configuration

### DIFF
--- a/ublox_gps/config/zed_f9p.yaml
+++ b/ublox_gps/config/zed_f9p.yaml
@@ -1,0 +1,5 @@
+device: /dev/ttyACM0
+frame_id: gps
+uart1:
+  baudrate: 38400
+config_on_startup: false


### PR DESCRIPTION
Add a new default configuration file for the F9P sensor.