### PR TITLE
Launch file improvements

### DIFF
--- a/ublox_gps/launch/ublox_device.launch
+++ b/ublox_gps/launch/ublox_device.launch
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <launch>
-  <arg name="node_name" />
-  <arg name="param_file_name" doc="name of param file, e.g. rover" />
-  <arg name="output" default="screen" />
-  <arg name="respawn" default="true" />
-  <arg name="respawn_delay" default="30" />
-  <arg name="clear_params" default="true" />
+  <arg name="param_file_name"     doc="name of param file, e.g. rover" />
+  <arg name="param_file_dir"      doc="directory to look for $(arg param_file_name).yaml"
+                                  default="$(find ublox_gps)/config" />
+
+  <arg name="node_name"           doc="name of this node"
+                                  default="ublox" />
+  <arg name="output"              default="screen" />
+  <arg name="respawn"             default="true" />
+  <arg name="respawn_delay"       default="30" />
+  <arg name="clear_params"        default="true" />
 
   <node pkg="ublox_gps" type="ublox_gps" name="$(arg node_name)"
-        output="$(arg output)" 
+        output="$(arg output)"
         clear_params="$(arg clear_params)"
-        respawn="$(arg respawn)" 
+        respawn="$(arg respawn)"
         respawn_delay="$(arg respawn_delay)">
-    <rosparam command="load" 
-              file="$(find ublox_gps)/config/$(arg param_file_name).yaml" />
+    <rosparam command="load"
+              file="$(arg param_file_dir)/$(arg param_file_name).yaml" />
   </node>
 </launch>


### PR DESCRIPTION
- Add a default value to the node_name argument
- Add a new param_file_dir argument to set the search path for the param_file_name.  This should allow config files present in external packages to be used more easily without duplicating the entire launch file.