### PR TITLE
No Launch Folder inside the install Directory

### DIFF
--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -93,4 +93,9 @@ install(DIRECTORY include/
   DESTINATION include
 )
 
+install(
+  DIRECTORY launch config
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()


### PR DESCRIPTION
After check the CMake of Foxy-devel, I've noticed that you don't "install" the launch and config folder to be able to launch using a simple command ```ros2 launch ublox_gps ublox_gps_node-launch.py``` instead of that, it's necessary to use the full path.

### **Added:**

```
install(
  DIRECTORY launch config
  DESTINATION share/${PROJECT_NAME}
)

```