### PR TITLE
Fix warnings in launch.

### DIFF
--- a/ublox_gps/launch/ublox_gps_node-composed-launch.py
+++ b/ublox_gps/launch/ublox_gps_node-composed-launch.py
@@ -51,15 +51,15 @@ def generate_launch_description():
     with open(param_config, 'r') as f:
         params = yaml.safe_load(f)['ublox_gps_node']['ros__parameters']
     container = ComposableNodeContainer(
-            node_name='ublox_gps_container',
-            node_namespace='',
+            name='ublox_gps_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='ublox_gps',
-                    node_plugin='ublox_node::UbloxNode',
-                    node_name='ublox_gps_node',
+                    plugin='ublox_node::UbloxNode',
+                    name='ublox_gps_node',
                     parameters=[params]),
             ],
             output='both',

--- a/ublox_gps/launch/ublox_gps_node-launch.py
+++ b/ublox_gps/launch/ublox_gps_node-launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
         'config')
     params = os.path.join(config_directory, 'c94_m8p_rover.yaml')
     ublox_gps_node = launch_ros.actions.Node(package='ublox_gps',
-                                             node_executable='ublox_gps_node',
+                                             executable='ublox_gps_node',
                                              output='both',
                                              parameters=[params])
 


### PR DESCRIPTION
Starting in Foxy, node_name, node_executable, node_plugin,
and node_namespace are deprecated and replaced with name,
executable, plugin, and namespace, respectively.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>