### PR TITLE
Add RTK support via rtcm

### DIFF
--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS tf roscpp ublox_msgs ublox_serialization)
+    CATKIN_DEPENDS tf roscpp ublox_msgs ublox_serialization rtcm_msgs)
 
 # include boost
 find_package(Boost REQUIRED COMPONENTS system regex thread)

--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   ublox_msgs
   ublox_serialization
   diagnostic_updater
+  rtcm_msgs
 )
 
 catkin_package(

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -116,6 +116,11 @@ class Gps {
   void resetSerial(std::string port);
 
   /**
+   * @brief Send rtcm correction message.
+  */
+  bool sendRtcm(const std::vector<uint8_t> &message);
+
+  /**
    * @brief Closes the I/O port, and initiates save on shutdown procedure
    * if enabled.
    */

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -57,6 +57,8 @@
 #include <ublox_gps/utils.h>
 #include <ublox_gps/raw_data_pa.h>
 
+#include <rtcm_msgs/Message.h>
+
 // This file declares the ComponentInterface which acts as a high level
 // interface for u-blox firmware, product categories, etc. It contains methods
 // to configure the u-blox and subscribe to u-blox messages.

--- a/ublox_gps/package.xml
+++ b/ublox_gps/package.xml
@@ -20,5 +20,6 @@
   <depend>roscpp_serialization</depend>
   <depend>tf</depend>
   <depend>diagnostic_updater</depend>
+  <depend>rtcm_msgs</depend>
 
 </package>

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -532,6 +532,11 @@ bool Gps::setUseAdr(bool enable, float protocol_version) {
   return configure(msg);
 }
 
+bool Gps::sendRtcm(const std::vector<uint8_t>& rtcm){
+  worker_->send(rtcm.data(), rtcm.size());
+  return true;
+}
+
 bool Gps::poll(uint8_t class_id, uint8_t message_id,
                const std::vector<uint8_t>& payload) {
   if (!worker_) return false;

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -1809,9 +1809,14 @@ void TimProduct::initializeRosDiagnostics() {
   updater->force_update();
 }
 
+void rtcmCallback(const rtcm_msgs::Message::ConstPtr &msg) {
+  gps.sendRtcm(msg->message);
+}
+
 int main(int argc, char** argv) {
   ros::init(argc, argv, "ublox_gps");
   nh.reset(new ros::NodeHandle("~"));
+  ros::Subscriber subRtcm = nh->subscribe("/rtcm", 10, rtcmCallback);
   nh->param("debug", ublox_gps::debug, 1);
   if(ublox_gps::debug) {
     if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME,


### PR DESCRIPTION
These changes are based on [this outdated repo](https://github.com/ros-agriculture/ublox_f9p) and add RTK support for high precision GNSS modules like the ZED-F9P.  The RTK support is based on rtcm corrections that are published via ROS and this creates a dependency to [rtcm_msgs](https://github.com/tilk/rtcm_msgs). The rtcm message itself is very basic (`Header + uint8 []`). 

I've tested this with my ZED-F9P and it works reliably. The changes would address #119,  #117, and #43.

All you would need to get RTK working now is to use an NTRIP client (or similar), that publishes RTCM messages via ROS on the `/rtcm` topic.