### PR TITLE
Add the types to declared parameters.

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -250,8 +250,8 @@ void UbloxNode::getRosParams() {
   uart_out_ = declareRosIntParameter<uint16_t>(this, "uart1.out", ublox_msgs::msg::CfgPRT::PROTO_UBX);
   // USB params
   set_usb_ = false;
-  this->declare_parameter("usb.in");
-  this->declare_parameter("usb.out");
+  this->declare_parameter<int64_t>("usb.in");
+  this->declare_parameter<int64_t>("usb.out");
   usb_tx_ = declareRosIntParameter<uint16_t>(this, "usb.tx_ready", 0);
   if (isRosParameterSet(this, "usb.in") || isRosParameterSet(this, "usb.out")) {
     set_usb_ = true;
@@ -271,8 +271,8 @@ void UbloxNode::getRosParams() {
   nav_rate_ = declareRosIntParameter<uint16_t>(this, "nav_rate", 1);  // # of measurement rate cycles
 
   // RTCM params
-  this->declare_parameter("rtcm.ids");
-  this->declare_parameter("rtcm.rates");
+  this->declare_parameter<std::vector<int64_t>>("rtcm.ids");
+  this->declare_parameter<std::vector<int64_t>>("rtcm.rates");
   std::vector<int64_t> rtcm_ids;
   std::vector<int64_t> rtcm_rates;
   this->get_parameter("rtcm.ids", rtcm_ids);
@@ -319,11 +319,11 @@ void UbloxNode::getRosParams() {
 
 
   this->declare_parameter("dat.set", false);
-  this->declare_parameter("dat.majA");
-  this->declare_parameter("dat.flat");
-  this->declare_parameter("dat.shift");
-  this->declare_parameter("dat.rot");
-  this->declare_parameter("dat.scale");
+  this->declare_parameter<double>("dat.majA");
+  this->declare_parameter<double>("dat.flat");
+  this->declare_parameter<std::vector<double>>("dat.shift");
+  this->declare_parameter<std::vector<double>>("dat.rot");
+  this->declare_parameter<double>("dat.scale");
   if (getRosBoolean(this, "dat.set")) {
     std::vector<double> shift, rot;
     if (!this->get_parameter("dat.majA", cfg_dat_.maj_a)
@@ -368,7 +368,7 @@ void UbloxNode::getRosParams() {
   this->declare_parameter("sv_in.min_dur", 0);
   this->declare_parameter("sv_in.acc_lim", 0.0);
 
-  this->declare_parameter("dgnss_mode");
+  this->declare_parameter<int64_t>("dgnss_mode");
 
   // raw data stream logging
   this->declare_parameter("raw_data_stream.enable", false);
@@ -450,9 +450,9 @@ void UbloxNode::getRosParams() {
   // HNR parameters
   this->declare_parameter("publish.hnr.pvt", true);
 
-  this->declare_parameter("tmode3");
-  this->declare_parameter("arp.position");
-  this->declare_parameter("arp.position_hp");
+  this->declare_parameter<int64_t>("tmode3");
+  this->declare_parameter<std::vector<double>>("arp.position");
+  this->declare_parameter<std::vector<int64_t>>("arp.position_hp");
   this->declare_parameter("arp.acc", 0.0);
   this->declare_parameter("arp.lla_flag", false);
 


### PR DESCRIPTION
This removes warnings when building on Galactic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that I created a new `galactic-devel` branch for this, since these changes only work on Galactic and later.