### PR TITLE
Fix parameter declaration types.

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -250,8 +250,8 @@ void UbloxNode::getRosParams() {
   uart_out_ = declareRosIntParameter<uint16_t>(this, "uart1.out", ublox_msgs::msg::CfgPRT::PROTO_UBX);
   // USB params
   set_usb_ = false;
-  this->declare_parameter<int64_t>("usb.in");
-  this->declare_parameter<int64_t>("usb.out");
+  this->declare_parameter("usb.in", rclcpp::PARAMETER_INTEGER);
+  this->declare_parameter("usb.out", rclcpp::PARAMETER_INTEGER);
   usb_tx_ = declareRosIntParameter<uint16_t>(this, "usb.tx_ready", 0);
   if (isRosParameterSet(this, "usb.in") || isRosParameterSet(this, "usb.out")) {
     set_usb_ = true;
@@ -271,8 +271,8 @@ void UbloxNode::getRosParams() {
   nav_rate_ = declareRosIntParameter<uint16_t>(this, "nav_rate", 1);  // # of measurement rate cycles
 
   // RTCM params
-  this->declare_parameter<std::vector<int64_t>>("rtcm.ids");
-  this->declare_parameter<std::vector<int64_t>>("rtcm.rates");
+  this->declare_parameter("rtcm.ids", rclcpp::PARAMETER_INTEGER_ARRAY);
+  this->declare_parameter("rtcm.rates", rclcpp::PARAMETER_INTEGER_ARRAY);
   std::vector<int64_t> rtcm_ids;
   std::vector<int64_t> rtcm_rates;
   this->get_parameter("rtcm.ids", rtcm_ids);
@@ -319,11 +319,11 @@ void UbloxNode::getRosParams() {
 
 
   this->declare_parameter("dat.set", false);
-  this->declare_parameter<double>("dat.majA");
-  this->declare_parameter<double>("dat.flat");
-  this->declare_parameter<std::vector<double>>("dat.shift");
-  this->declare_parameter<std::vector<double>>("dat.rot");
-  this->declare_parameter<double>("dat.scale");
+  this->declare_parameter("dat.majA", rclcpp::PARAMETER_DOUBLE);
+  this->declare_parameter("dat.flat", rclcpp::PARAMETER_DOUBLE);
+  this->declare_parameter("dat.shift", rclcpp::PARAMETER_DOUBLE_ARRAY);
+  this->declare_parameter("dat.rot", rclcpp::PARAMETER_DOUBLE_ARRAY);
+  this->declare_parameter("dat.scale", rclcpp::PARAMETER_DOUBLE);
   if (getRosBoolean(this, "dat.set")) {
     std::vector<double> shift, rot;
     if (!this->get_parameter("dat.majA", cfg_dat_.maj_a)
@@ -368,7 +368,7 @@ void UbloxNode::getRosParams() {
   this->declare_parameter("sv_in.min_dur", 0);
   this->declare_parameter("sv_in.acc_lim", 0.0);
 
-  this->declare_parameter<int64_t>("dgnss_mode");
+  this->declare_parameter("dgnss_mode", rclcpp::PARAMETER_INTEGER);
 
   // raw data stream logging
   this->declare_parameter("raw_data_stream.enable", false);
@@ -450,9 +450,9 @@ void UbloxNode::getRosParams() {
   // HNR parameters
   this->declare_parameter("publish.hnr.pvt", true);
 
-  this->declare_parameter<int64_t>("tmode3");
-  this->declare_parameter<std::vector<double>>("arp.position");
-  this->declare_parameter<std::vector<int64_t>>("arp.position_hp");
+  this->declare_parameter("tmode3", rclcpp::PARAMETER_INTEGER);
+  this->declare_parameter("arp.position", rclcpp::PARAMETER_DOUBLE_ARRAY);
+  this->declare_parameter("arp.position_hp", rclcpp::PARAMETER_INTEGER_ARRAY);
   this->declare_parameter("arp.acc", 0.0);
   this->declare_parameter("arp.lla_flag", false);
 


### PR DESCRIPTION
Instead of trying to force things with template arguments,
instead explicitly declare the type when declaring arguments
without a default.  This should allow the types to be properly
set while still allowing these to be run without a type explicitly
set.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #145 