### PR TITLE
Revamp the building of the driver for modern ROS 2 practices.

### DIFF
--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -26,8 +26,6 @@ find_package(tf2 REQUIRED)
 find_package(ublox_msgs REQUIRED)
 find_package(ublox_serialization REQUIRED)
 
-include_directories(include)
-
 # build node
 add_library(ublox_gps
   src/adr_udr_product.cpp
@@ -46,43 +44,48 @@ add_library(ublox_gps
   src/ublox_firmware7.cpp
   src/ublox_firmware8.cpp
   src/ublox_firmware9.cpp)
-ament_target_dependencies(ublox_gps
-  "asio"
-  "diagnostic_msgs"
-  "diagnostic_updater"
-  "geometry_msgs"
-  "rcl_interfaces"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs"
-  "std_msgs"
-  "tf2"
-  "ublox_msgs"
-  "ublox_serialization"
+target_include_directories(ublox_gps PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  ${diagnostic_updater_INCLUDE_DIRS}
+)
+target_link_libraries(ublox_gps PUBLIC
+  ${asio_LIBRARIES}
+  ${diagnostic_updater_LIBRARIES}
+  ${diagnostic_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${rcl_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  tf2::tf2
+  ${ublox_msgs_TARGETS}
+  ublox_serialization::ublox_serialization
 )
 
-install(TARGETS ublox_gps
+install(TARGETS ublox_gps EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
 add_executable(ublox_gps_node src/node_main.cpp)
-ament_target_dependencies(ublox_gps_node
-  "rclcpp"
+target_link_libraries(ublox_gps_node PRIVATE
+  rclcpp::rclcpp
+  ublox_gps
 )
-target_link_libraries(ublox_gps_node ublox_gps)
 
 # build logger node
-add_executable(ublox_logger_node src/logger_node_pa.cpp src/raw_data_pa.cpp)
-set_target_properties(ublox_logger_node PROPERTIES OUTPUT_NAME ublox_logger)
-ament_target_dependencies(ublox_logger_node
-  "rclcpp"
-  "std_msgs"
+add_executable(ublox_logger src/logger_node_pa.cpp src/raw_data_pa.cpp)
+target_link_libraries(ublox_logger PRIVATE
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS}
+  ublox_gps
 )
 
 install(TARGETS
-  ublox_gps_node ublox_logger_node
+  ublox_gps_node ublox_logger
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -90,12 +93,15 @@ rclcpp_components_register_nodes(ublox_gps
   "ublox_node::UbloxNode")
 
 install(DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(
   DIRECTORY launch config
   DESTINATION share/${PROJECT_NAME}
 )
+
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_targets(export_${PROJECT_NAME})
 
 ament_package()

--- a/ublox_msgs/CMakeLists.txt
+++ b/ublox_msgs/CMakeLists.txt
@@ -103,26 +103,32 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     std_msgs
 )
 
-include_directories(include)
-add_library(${PROJECT_NAME}_lib src/ublox_msgs.cpp)
-rosidl_target_interfaces(${PROJECT_NAME}_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
-ament_target_dependencies(${PROJECT_NAME}_lib
-  "ublox_serialization"
-)
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
+if(cpp_typesupport_target)
+  add_library(${PROJECT_NAME}_lib src/ublox_msgs.cpp)
+  target_include_directories(${PROJECT_NAME}_lib PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+  target_link_libraries(${PROJECT_NAME}_lib
+    ${cpp_typesupport_target}
+    ublox_serialization::ublox_serialization
+  )
 
-install(TARGETS ${PROJECT_NAME}_lib EXPORT ${PROJECT_NAME}_lib
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
+  install(TARGETS ${PROJECT_NAME}_lib EXPORT ${PROJECT_NAME}_lib
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
 
-install(DIRECTORY include/
-  DESTINATION include
-)
+  install(DIRECTORY include/
+    DESTINATION "include/${PROJECT_NAME}"
+  )
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME}_lib)
-ament_export_targets(${PROJECT_NAME}_lib)
+  ament_export_include_directories("include/${PROJECT_NAME}")
+  ament_export_libraries(${PROJECT_NAME}_lib)
+  ament_export_targets(${PROJECT_NAME}_lib)
+endif()
+
 ament_export_dependencies(rosidl_default_runtime sensor_msgs std_msgs ublox_serialization)
 
 ament_package()

--- a/ublox_serialization/CMakeLists.txt
+++ b/ublox_serialization/CMakeLists.txt
@@ -4,10 +4,18 @@ project(ublox_serialization)
 
 find_package(ament_cmake REQUIRED)
 
-install(DIRECTORY include/
-  DESTINATION include
-)
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-ament_export_include_directories(include)
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
+
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+ament_export_targets(export_${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
This includes getting rid of ament_target_dependencies in
favor of target_link_libraries, installing includes to another
level down in the hierarchy, and generally making things use
modern CMake.

Note that all of this only applies to ROS 2 Humble and later.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the builds on the Rolling build farm: https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__ublox_msgs__ubuntu_jammy_amd64__binary/ .

Please notice that I've now created a new branch called `ros2`, which is meant to hold the development version of the ROS 2 port.  `galactic-devel` will still be used for Galactic, etc.