### PR TITLE
feature publish NMEA sentences

### DIFF
--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -8,12 +8,13 @@ find_package(catkin REQUIRED COMPONENTS
   ublox_serialization
   diagnostic_updater
   rtcm_msgs
+  nmea_msgs
 )
 
 catkin_package(
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS tf roscpp ublox_msgs ublox_serialization rtcm_msgs)
+    CATKIN_DEPENDS tf roscpp ublox_msgs ublox_serialization rtcm_msgs nmea_msgs)
 
 # include boost
 find_package(Boost REQUIRED COMPONENTS system regex thread)

--- a/ublox_gps/include/ublox_gps/callback.h
+++ b/ublox_gps/include/ublox_gps/callback.h
@@ -187,13 +187,13 @@ class CallbackHandlers {
 
     const std::string& buffer = reader.getUnusedData();
     size_t nmea_start = buffer.find('$', 0);
-    size_t nmea_end = buffer.find('\n', 0);
+    size_t nmea_end = buffer.find('\n', nmea_start);
     while(nmea_start != std::string::npos && nmea_end != std::string::npos) {
         std::string sentence = buffer.substr(nmea_start, nmea_end - nmea_start + 1);
         callback_nmea_(sentence);
 
         nmea_start = buffer.find('$', nmea_end+1);
-        nmea_end = buffer.find('\n', nmea_end+1);
+        nmea_end = buffer.find('\n', nmea_start);
     }
   }
 

--- a/ublox_gps/include/ublox_gps/callback.h
+++ b/ublox_gps/include/ublox_gps/callback.h
@@ -154,6 +154,15 @@ class CallbackHandlers {
   }
 
   /**
+   * @brief Add a callback handler for nmea messages
+   * @param callback the callback handler for the message
+   */
+  void set_nmea_callback(boost::function<void(const std::string&)> callback) {
+    boost::mutex::scoped_lock lock(callback_mutex_);
+    callback_nmea_ = callback;
+  }
+
+  /**
    * @brief Calls the callback handler for the message in the reader.
    * @param reader a reader containing a u-blox message
    */
@@ -165,6 +174,27 @@ class CallbackHandlers {
     for (Callbacks::iterator callback = callbacks_.lower_bound(key);
          callback != callbacks_.upper_bound(key); ++callback)
       callback->second->handle(reader);
+  }
+
+  /**
+   * @brief Calls the callback handler for the nmea messages in the reader.
+   * @param reader a reader containing an nmea message
+   */
+  void handle_nmea(ublox::Reader& reader) {
+    boost::mutex::scoped_lock lock(callback_mutex_);
+    if(callback_nmea_.empty())
+        return;
+
+    const std::string& buffer = reader.getUnusedData();
+    size_t nmea_start = buffer.find('$', 0);
+    size_t nmea_end = buffer.find('\n', 0);
+    while(nmea_start != std::string::npos && nmea_end != std::string::npos) {
+        std::string sentence = buffer.substr(nmea_start, nmea_end - nmea_start + 1);
+        callback_nmea_(sentence);
+
+        nmea_start = buffer.find('$', nmea_end+1);
+        nmea_end = buffer.find('\n', nmea_end+1);
+    }
   }
 
   /**
@@ -218,6 +248,7 @@ class CallbackHandlers {
 
       handle(reader);
     }
+    handle_nmea(reader);
 
     // delete read bytes from ASIO input buffer
     std::copy(reader.pos(), reader.end(), data);
@@ -231,6 +262,9 @@ class CallbackHandlers {
   // Call back handlers for u-blox messages
   Callbacks callbacks_;
   boost::mutex callback_mutex_;
+  
+  //! Callback handler for nmea messages
+  boost::function<void(const std::string&)> callback_nmea_;
 };
 
 }  // namespace ublox_gps

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -345,6 +345,12 @@ class Gps {
   void subscribe(typename CallbackHandler_<T>::Callback callback);
 
   /**
+   * @brief Subscribe to the given Ublox message.
+   * @param the callback handler for the message
+   */
+  void subscribe_nmea(boost::function<void(const std::string&)> callback) { callbacks_.set_nmea_callback(callback); }
+
+  /**
    * @brief Subscribe to the message with the given ID. This is used for
    * messages which have the same format but different message IDs,
    * e.g. INF messages.

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -50,6 +50,7 @@
 #include <sensor_msgs/NavSatFix.h>
 #include <sensor_msgs/TimeReference.h>
 #include <sensor_msgs/Imu.h>
+#include <nmea_msgs/Sentence.h>
 // Other U-Blox package includes
 #include <ublox_msgs/ublox_msgs.h>
 // Ublox GPS includes
@@ -424,6 +425,16 @@ template <typename MessageT>
 void publish(const MessageT& m, const std::string& topic) {
   static ros::Publisher publisher = nh->advertise<MessageT>(topic,
                                                             kROSQueueSize);
+  publisher.publish(m);
+}
+
+void publish_nmea(const std::string& sentence, const std::string& topic) {
+  static ros::Publisher publisher = nh->advertise<nmea_msgs::Sentence>(topic,
+                                                            kROSQueueSize);
+  nmea_msgs::Sentence m;
+  m.header.stamp = ros::Time::now();
+  m.header.frame_id = frame_id;
+  m.sentence = sentence;
   publisher.publish(m);
 }
 

--- a/ublox_gps/package.xml
+++ b/ublox_gps/package.xml
@@ -16,6 +16,7 @@
 
   <depend>ublox_serialization</depend>
   <depend>ublox_msgs</depend>
+  <depend>nmea_msgs</depend>
   <depend>roscpp</depend>
   <depend>roscpp_serialization</depend>
   <depend>tf</depend>

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -288,6 +288,10 @@ void UbloxNode::subscribe() {
     gps.subscribe<ublox_msgs::NavCLOCK>(boost::bind(
         publish<ublox_msgs::NavCLOCK>, _1, "navclock"), kSubscribeRate);
 
+  nh->param("publish/nmea", enabled["nmea"], false);
+  if (enabled["nmea"])
+    gps.subscribe_nmea(boost::bind(publish_nmea, _1, "nmea"));
+
   // INF messages
   nh->param("inf/debug", enabled["inf_debug"], false);
   if (enabled["inf_debug"])
@@ -1127,8 +1131,11 @@ void UbloxFirmware8::getRosParams() {
 
     std::vector<uint8_t> bdsTalkerId;
     getRosUint("nmea/bds_talker_id", bdsTalkerId);
-    cfg_nmea_.bdsTalkerId[0] = bdsTalkerId[0];
-    cfg_nmea_.bdsTalkerId[1] = bdsTalkerId[1];
+    if(bdsTalkerId.size() >= 2) {
+      cfg_nmea_.bdsTalkerId[0] = bdsTalkerId[0];
+      cfg_nmea_.bdsTalkerId[1] = bdsTalkerId[1];
+    }
+
   }
 }
 

--- a/ublox_serialization/include/ublox/serialization.h
+++ b/ublox_serialization/include/ublox/serialization.h
@@ -179,7 +179,10 @@ class Reader {
    */
   Reader(const uint8_t *data, uint32_t count, 
          const Options &options = Options()) : 
-      data_(data), count_(count), found_(false), options_(options) {}
+      data_(data), count_(count), found_(false), options_(options)
+  {
+          unused_data_.reserve(1024);
+  }
 
   typedef const uint8_t *iterator;
 
@@ -190,7 +193,6 @@ class Reader {
   iterator search()
   {
     if (found_) next();
-
     // Search for a message header
     for( ; count_ > 0; --count_, ++data_) {
       if (data_[0] == options_.sync_a && 
@@ -204,6 +206,9 @@ class Reader {
 	  continue;
         }
         break;
+      }
+      else {
+          unused_data_.push_back(data_[0]);
       }
     }
 
@@ -328,10 +333,14 @@ class Reader {
     if (!found()) return false;
     return (classId() == class_id && messageId() == message_id);
   }
+  
+  const std::string& getUnusedData() const { return unused_data_; }
 
  private:
   //! The buffer of message bytes
-  const uint8_t *data_; 
+  const uint8_t *data_;
+  //! Unused data from the read buffer, contains nema messages.
+  std::string unused_data_;
   //! the number of bytes in the buffer, //! decrement as the buffer is read
   uint32_t count_; 
   //! Whether or not a message has been found

--- a/ublox_serialization/include/ublox/serialization.h
+++ b/ublox_serialization/include/ublox/serialization.h
@@ -339,7 +339,7 @@ class Reader {
  private:
   //! The buffer of message bytes
   const uint8_t *data_;
-  //! Unused data from the read buffer, contains nema messages.
+  //! Unused data from the read buffer, contains nmea messages.
   std::string unused_data_;
   //! the number of bytes in the buffer, //! decrement as the buffer is read
   uint32_t count_; 


### PR DESCRIPTION
This feature buffers the discarded bytes from the u-blox message reader, which typically contain the NMEA message string transmitted by the gps receiver. The messages are published as ROS nmea_msgs/Sentence if the config parameter "publish/nmea" is true.
This is useful for monitoring the full receiver output and when using internet-based NTRIP correction data, which require the receivers approximate position via a the NMEA GGA message.