### PR TITLE
correct NED to ENU yaw conversion formula

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -1793,8 +1793,7 @@ void HpPosRecProduct::callbackNavRelPosNed(const ublox_msgs::NavRELPOSNED9 &m) {
     imu_.angular_velocity_covariance[0] = -1;
 
     // Transform angle since ublox is representing heading as NED but ROS uses ENU as convention (REP-103).
-    // Also convert the base-to-rover angle to a robot-to-base angle (consistent with frame_id)
-    double heading = - (static_cast<double>(m.relPosHeading) * 1e-5 / 180.0 * M_PI) - M_PI_2;
+    double heading = M_PI_2 - (static_cast<double>(m.relPosHeading) * 1e-5 / 180.0 * M_PI);
     tf::Quaternion orientation;
     orientation.setRPY(0, 0, heading);
     imu_.orientation.x = orientation[0];


### PR DESCRIPTION
In the code the formula to convert heading from NED to ENU was like:

double heading = - (static_cast(m.relPosHeading) * 1e-5 / 180.0 * M_PI) - M_PI_2;

But I think it should be:

double heading = M_PI_2 - (static_cast(m.relPosHeading) * 1e-5 / 180.0 * M_PI);

If I am not wrong, the conversion of yaw from NED to ENU should be something like: ENUYaw = 90 - NEDYaw. I dont understand why the code considered ENUYaw = -90 - NEDYaw, that leads to an error of 180 degrees when the robot frame is aligned with ENU.

Best regards