### PR TITLE
remove periodical force update

### DIFF
--- a/ublox_gps/include/ublox_gps/ublox_firmware7plus.hpp
+++ b/ublox_gps/include/ublox_gps/ublox_firmware7plus.hpp
@@ -138,7 +138,6 @@ class UbloxFirmware7Plus : public UbloxFirmware {
     //
     last_nav_pvt_ = m;
     freq_diag_->diagnostic->tick(fix.header.stamp);
-    updater_->force_update();
   }
 
  protected:

--- a/ublox_gps/src/adr_udr_product.cpp
+++ b/ublox_gps/src/adr_udr_product.cpp
@@ -202,7 +202,6 @@ void AdrUdrProduct::callbackEsfMEAS(const ublox_msgs::msg::EsfMEAS &m) {
     }
   }
 
-  updater_->force_update();
 }
 
 }  // namespace ublox_node

--- a/ublox_gps/src/hp_pos_rec_product.cpp
+++ b/ublox_gps/src/hp_pos_rec_product.cpp
@@ -74,7 +74,6 @@ void HpPosRecProduct::callbackNavRelPosNed(const ublox_msgs::msg::NavRELPOSNED9 
   }
 
   last_rel_pos_ = m;
-  updater_->force_update();
 }
 
 }  // namespace ublox_node

--- a/ublox_gps/src/hpg_ref_product.cpp
+++ b/ublox_gps/src/hpg_ref_product.cpp
@@ -188,7 +188,6 @@ void HpgRefProduct::callbackNavSvIn(const ublox_msgs::msg::NavSVIN& m) {
     setTimeMode(gps_);
   }
 
-  updater_->force_update();
 }
 
 bool HpgRefProduct::setTimeMode(std::shared_ptr<ublox_gps::Gps> gps) {

--- a/ublox_gps/src/hpg_rov_product.cpp
+++ b/ublox_gps/src/hpg_rov_product.cpp
@@ -98,7 +98,6 @@ void HpgRovProduct::callbackNavRelPosNed(const ublox_msgs::msg::NavRELPOSNED &m)
   }
 
   last_rel_pos_ = m;
-  updater_->force_update();
 }
 
 }  // namespace ublox_node

--- a/ublox_gps/src/tim_product.cpp
+++ b/ublox_gps/src/tim_product.cpp
@@ -90,7 +90,6 @@ void TimProduct::callbackTimTM2(const ublox_msgs::msg::TimTM2 &m) {
     interrupt_time_pub_->publish(t_ref_);
   }
 
-  updater_->force_update();
 }
 
 void TimProduct::initializeRosDiagnostics() {

--- a/ublox_gps/src/ublox_firmware6.cpp
+++ b/ublox_gps/src/ublox_firmware6.cpp
@@ -204,7 +204,6 @@ void UbloxFirmware6::callbackNavPosLlh(const ublox_msgs::msg::NavPOSLLH& m) {
   last_nav_pos_ = m;
   //  update diagnostics
   freq_diag_->diagnostic->tick(fix_.header.stamp);
-  updater_->force_update();
 }
 
 void UbloxFirmware6::callbackNavVelNed(const ublox_msgs::msg::NavVELNED& m) {


### PR DESCRIPTION
- In ROS2, diagnostic_updater::Updater calls update() using timer
- force_update() is not necessary.