### PR TITLE
Link atomic to ublox_gps

### DIFF
--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -51,6 +51,7 @@ target_include_directories(ublox_gps PUBLIC
 )
 target_link_libraries(ublox_gps PUBLIC
   ${asio_LIBRARIES}
+  atomic
   ${diagnostic_updater_LIBRARIES}
   ${diagnostic_msgs_TARGETS}
   ${geometry_msgs_TARGETS}


### PR DESCRIPTION
Currently, if I build this repository with Clang, it causes errors of `undefined reference` to some `__atomic_*` functions.

```sh-session
$ CXX=clang++ colcon build
...
/usr/bin/ld: libublox_gps.so: undefined reference to `__atomic_load'
/usr/bin/ld: libublox_gps.so: undefined reference to `__atomic_store'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [CMakeFiles/ublox_gps_node.dir/build.make:286: ublox_gps_node] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:167: CMakeFiles/ublox_gps_node.dir/all] Error 2
```

According to the [Clang documentation](https://clang.llvm.org/docs/Toolchain.html#atomics-library), we have to link it manually.

> Clang does not currently automatically link against libatomic when using libgcc_s. You may need to manually add -latomic to support this configuration when using non-native atomic operations (if you see link errors referring to __atomic_* functions).

I know that Clang isn't the main target, but as I guess it doesn't affect GCC, I think it's good to link it.