### PR TITLE
Adding minimal support for ZED-F9K device

### DIFF
--- a/ublox_gps/config/zed_f9k.yaml
+++ b/ublox_gps/config/zed_f9k.yaml
@@ -1,5 +1,7 @@
+# Configuration Settings for ZED-F9K device
+# Please change these settings according as necessary
 device: /dev/ttyACM0
-frame_id: ublox_gps
+frame_id: gps
 uart1:
   baudrate: 115200
 config_on_startup: true
@@ -7,17 +9,16 @@ rate: 20                     # in Hz
 nav_rate: 1                  # [# of measurement cycles], recommended 1 Hz, may
 dgnss_mode: 3                # Fixed mode
 dynamic_model: automotive    # automative mode
-use_adr: true
+use_adr: true                # Whether to enable dead reckoning
 
 inf:
-  all: false                   # Whether to display all INF messages in console
+  all: false                 # Whether to display all INF messages in console
 
-# Enable u-blox message publishers
+# Enable necessary u-blox message publishers
 publish:
   all: false
   esf:
     meas: true
-  mon_hw: false
   nav:
     status: true
     pvt: true

--- a/ublox_gps/config/zed_f9k.yaml
+++ b/ublox_gps/config/zed_f9k.yaml
@@ -1,0 +1,25 @@
+device: /dev/ttyACM0
+frame_id: ublox_gps
+uart1:
+  baudrate: 115200
+config_on_startup: true
+rate: 20                     # in Hz
+nav_rate: 1                  # [# of measurement cycles], recommended 1 Hz, may
+dgnss_mode: 3                # Fixed mode
+dynamic_model: automotive    # automative mode
+use_adr: true
+
+inf:
+  all: false                   # Whether to display all INF messages in console
+
+# Enable u-blox message publishers
+publish:
+  all: false
+  esf:
+    meas: true
+  mon_hw: false
+  nav:
+    status: true
+    pvt: true
+    posecef: false
+    hpposllh: true

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -124,14 +124,15 @@ void UbloxNode::addProductInterface(std::string product_category,
   else if (product_category.compare("TIM") == 0)
     components_.push_back(ComponentPtr(new TimProduct));
   else if (product_category.compare("ADR") == 0 ||
-           product_category.compare("UDR") == 0)
+           product_category.compare("UDR") == 0 ||
+           product_category.compare("LAP") == 0)
     components_.push_back(ComponentPtr(new AdrUdrProduct(protocol_version_)));
   else if (product_category.compare("FTS") == 0)
     components_.push_back(ComponentPtr(new FtsProduct));
   else if(product_category.compare("SPG") != 0)
     ROS_WARN("Product category %s %s from MonVER message not recognized %s",
              product_category.c_str(), ref_rov.c_str(),
-             "options are HPG REF, HPG ROV, HPG #.#, HDG #.#, TIM, ADR, UDR, FTS, SPG");
+             "options are HPG REF, HPG ROV, HPG #.#, HDG #.#, TIM, ADR, UDR, LAP, FTS, SPG");
 }
 
 void UbloxNode::getRosParams() {
@@ -1410,8 +1411,8 @@ void AdrUdrProduct::callbackEsfMEAS(const ublox_msgs::EsfMEAS &m) {
       } else if (data_type == 12) {
         //ROS_INFO("Temperature in celsius: %f", data_value * deg_c); 
       } else {
-        ROS_INFO("data_type: %u", data_type);
-        ROS_INFO("data_value: %u", data_value);
+        // ROS_INFO("data_type: %u", data_type);
+        // ROS_INFO("data_value: %u", data_value);
       }
 
       // create time ref message and put in the data


### PR DESCRIPTION
The ZED-F9K is a LAP category device, which is currently not supported by the driver. This PR aims to introduce ZED-F9K as an Automotive Dead Reckoning (ADR) module in the driver and enable publishing ESF messages, including IMU data. 

See issue #102 