### PR TITLE
Add position and velocity covariance message (UBX_NAV_COV)

### DIFF
--- a/ublox_gps/include/ublox_gps/node.hpp
+++ b/ublox_gps/include/ublox_gps/node.hpp
@@ -265,6 +265,7 @@ class UbloxNode final : public rclcpp::Node {
   rclcpp::Publisher<ublox_msgs::msg::NavSTATUS>::SharedPtr nav_status_pub_;
   rclcpp::Publisher<ublox_msgs::msg::NavPOSECEF>::SharedPtr nav_posecef_pub_;
   rclcpp::Publisher<ublox_msgs::msg::NavCLOCK>::SharedPtr nav_clock_pub_;
+  rclcpp::Publisher<ublox_msgs::msg::NavCOV>::SharedPtr nav_cov_pub_;
   rclcpp::Publisher<ublox_msgs::msg::AidALM>::SharedPtr aid_alm_pub_;
   rclcpp::Publisher<ublox_msgs::msg::AidEPH>::SharedPtr aid_eph_pub_;
   rclcpp::Publisher<ublox_msgs::msg::AidHUI>::SharedPtr aid_hui_pub_;

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -549,6 +549,11 @@ void UbloxNode::subscribe() {
                                           1);
   }
 
+  if (getRosBoolean(this, "publish.nav.cov")) {
+    gps_->subscribe<ublox_msgs::msg::NavCOV>([this](const ublox_msgs::msg::NavCOV &m) { nav_cov_pub_->publish(m); },
+                                          1);
+  }
+
   // INF messages
   if (getRosBoolean(this, "inf.debug")) {
     gps_->subscribeId<ublox_msgs::msg::Inf>(

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -52,6 +52,7 @@
 #include <ublox_msgs/msg/inf.hpp>
 #include <ublox_msgs/msg/mon_ver.hpp>
 #include <ublox_msgs/msg/nav_clock.hpp>
+#include <ublox_msgs/msg/nav_cov.hpp>
 #include <ublox_msgs/msg/nav_posecef.hpp>
 #include <ublox_msgs/msg/nav_status.hpp>
 
@@ -410,6 +411,7 @@ void UbloxNode::getRosParams() {
   this->declare_parameter("publish.nav.all", getRosBoolean(this, "publish.all"));
   this->declare_parameter("publish.nav.att", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.clock", getRosBoolean(this, "publish.nav.all"));
+  this->declare_parameter("publish.nav.cov", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.heading", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.posecef", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.posllh", getRosBoolean(this, "publish.nav.all"));
@@ -472,8 +474,8 @@ void UbloxNode::getRosParams() {
   if (getRosBoolean(this, "publish.nav.posecef")) {
     nav_posecef_pub_ = this->create_publisher<ublox_msgs::msg::NavPOSECEF>("navposecef", 1);
   }
-  if (getRosBoolean(this, "publish.nav.clock")) {
-    nav_clock_pub_ = this->create_publisher<ublox_msgs::msg::NavCLOCK>("navclock", 1);
+  if (getRosBoolean(this, "publish.nav.cov")) {
+    nav_cov_pub_ = this->create_publisher<ublox_msgs::msg::NavCOV>("navcov", 1);
   }
   if (getRosBoolean(this, "publish.nav.clock")) {
     nav_clock_pub_ = this->create_publisher<ublox_msgs::msg::NavCLOCK>("navclock", 1);

--- a/ublox_msgs/CMakeLists.txt
+++ b/ublox_msgs/CMakeLists.txt
@@ -58,6 +58,7 @@ set(msg_files
   "msg/MonVER.msg"
   "msg/NavATT.msg"
   "msg/NavCLOCK.msg"
+  "msg/NavCOV.msg"
   "msg/NavDGPS.msg"
   "msg/NavDGPSSV.msg"
   "msg/NavDOP.msg"

--- a/ublox_msgs/include/ublox_msgs/serialization.hpp
+++ b/ublox_msgs/include/ublox_msgs/serialization.hpp
@@ -1505,6 +1505,56 @@ struct UbloxSerializer<ublox_msgs::msg::NavCLOCK_<ContainerAllocator> > {
 };
 
 template <typename ContainerAllocator>
+struct UbloxSerializer<ublox_msgs::msg::NavCOV_<ContainerAllocator> > {
+  inline static void read(const uint8_t *data, uint32_t count,
+                          ublox_msgs::msg::NavCOV_<ContainerAllocator> & m) {
+    UbloxIStream stream(const_cast<uint8_t *>(data), count);
+    stream.next(m.i_tow);
+    stream.next(m.pos_cov_valid);
+    stream.next(m.vel_cov_valid);
+    stream.next(m.reserved_0);
+    stream.next(m.pos_cov_nn);
+    stream.next(m.pos_cov_ne);
+    stream.next(m.pos_cov_nd);
+    stream.next(m.pos_cov_ee);
+    stream.next(m.pos_cov_ed);
+    stream.next(m.pos_cov_dd);
+    stream.next(m.vel_cov_nn);
+    stream.next(m.vel_cov_ne);
+    stream.next(m.vel_cov_nd);
+    stream.next(m.vel_cov_ee);
+    stream.next(m.vel_cov_ed);
+    stream.next(m.vel_cov_dd);
+  }
+
+  inline static uint32_t serializedLength(const ublox_msgs::msg::NavCOV_<ContainerAllocator> & m) {
+    (void)m;
+    return 64;
+  }
+
+  inline static void write(uint8_t *data, uint32_t size,
+                           const ublox_msgs::msg::NavCOV_<ContainerAllocator> & m) {
+    UbloxOStream stream(data, size);
+    stream.next(m.i_tow);
+    stream.next(m.pos_cov_valid);
+    stream.next(m.vel_cov_valid);
+    stream.next(m.reserved_0);
+    stream.next(m.pos_cov_nn);
+    stream.next(m.pos_cov_ne);
+    stream.next(m.pos_cov_nd);
+    stream.next(m.pos_cov_ee);
+    stream.next(m.pos_cov_ed);
+    stream.next(m.pos_cov_dd);
+    stream.next(m.vel_cov_nn);
+    stream.next(m.vel_cov_ne);
+    stream.next(m.vel_cov_nd);
+    stream.next(m.vel_cov_ee);
+    stream.next(m.vel_cov_ed);
+    stream.next(m.vel_cov_dd);
+  }
+};
+
+template <typename ContainerAllocator>
 struct UbloxSerializer<ublox_msgs::msg::NavDGPSSV_<ContainerAllocator> > {
   inline static void read(UbloxIStream& stream, ublox_msgs::msg::NavDGPSSV_<ContainerAllocator> & m) {
     stream.next(m.svid);

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
@@ -31,6 +31,7 @@
 
 #include <ublox_msgs/msg/nav_att.hpp>
 #include <ublox_msgs/msg/nav_clock.hpp>
+#include <ublox_msgs/msg/NavCOV.msg>
 #include <ublox_msgs/msg/nav_dgps.hpp>
 #include <ublox_msgs/msg/nav_dop.hpp>
 #include <ublox_msgs/msg/nav_posecef.hpp>
@@ -154,6 +155,7 @@ namespace Message {
   namespace NAV {
     static const uint8_t ATT = ublox_msgs::msg::NavATT::MESSAGE_ID;
     static const uint8_t CLOCK = ublox_msgs::msg::NavCLOCK::MESSAGE_ID;
+    static const uint8_t COV = ublox_msgs::msg::NavCOV::MESSAGE_ID;
     static const uint8_t DGPS = ublox_msgs::msg::NavDGPS::MESSAGE_ID;
     static const uint8_t DOP = ublox_msgs::msg::NavDOP::MESSAGE_ID;
     static const uint8_t POSECEF = ublox_msgs::msg::NavPOSECEF::MESSAGE_ID;

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
@@ -31,7 +31,7 @@
 
 #include <ublox_msgs/msg/nav_att.hpp>
 #include <ublox_msgs/msg/nav_clock.hpp>
-#include <ublox_msgs/msg/NavCOV.msg>
+#include <ublox_msgs/msg/nav_cov.hpp>
 #include <ublox_msgs/msg/nav_dgps.hpp>
 #include <ublox_msgs/msg/nav_dop.hpp>
 #include <ublox_msgs/msg/nav_posecef.hpp>

--- a/ublox_msgs/msg/NavCOV.msg
+++ b/ublox_msgs/msg/NavCOV.msg
@@ -1,0 +1,28 @@
+# NAV-COV (0x01 0x36)
+# Covariance matrices for position and velocity solutions
+#
+
+uint8 CLASS_ID = 1
+uint8 MESSAGE_ID = 54
+
+uint32 i_tow             # GPS Millisecond time of week [ms]
+
+uint8 version            # Message version (0x00 for this version)
+uint8 pos_cov_valid      # Position covariance matrix validity flag
+uint8 vel_cov_valid      # Velocity covariance matrix validity flag
+uint8[9] reserved_0      # Reserved
+
+float32 pos_cov_nn       # Position covariance matrix value p_NN
+float32 pos_cov_ne       # Position covariance matrix value p_NE
+float32 pos_cov_nd       # Position covariance matrix value p_ND
+float32 pos_cov_ee       # Position covariance matrix value p_EE
+float32 pos_cov_ed       # Position covariance matrix value p_ED
+float32 pos_cov_dd       # Position covariance matrix value p_DD
+
+
+float32 vel_cov_nn       # Velocity covariance matrix value v_NN
+float32 vel_cov_ne       # Velocity covariance matrix value v_NE
+float32 vel_cov_nd       # Velocity covariance matrix value v_ND
+float32 vel_cov_ee       # Velocity covariance matrix value v_EE
+float32 vel_cov_ed       # Velocity covariance matrix value v_ED
+float32 vel_cov_dd       # Velocity covariance matrix value v_DD

--- a/ublox_msgs/msg/NavCOV.msg
+++ b/ublox_msgs/msg/NavCOV.msg
@@ -12,17 +12,17 @@ uint8 pos_cov_valid      # Position covariance matrix validity flag
 uint8 vel_cov_valid      # Velocity covariance matrix validity flag
 uint8[9] reserved_0      # Reserved
 
-float32 pos_cov_nn       # Position covariance matrix value p_NN
-float32 pos_cov_ne       # Position covariance matrix value p_NE
-float32 pos_cov_nd       # Position covariance matrix value p_ND
-float32 pos_cov_ee       # Position covariance matrix value p_EE
-float32 pos_cov_ed       # Position covariance matrix value p_ED
-float32 pos_cov_dd       # Position covariance matrix value p_DD
+float32 pos_cov_nn       # Position covariance matrix value p_NN [m^2]
+float32 pos_cov_ne       # Position covariance matrix value p_NE [m^2]
+float32 pos_cov_nd       # Position covariance matrix value p_ND [m^2]
+float32 pos_cov_ee       # Position covariance matrix value p_EE [m^2]
+float32 pos_cov_ed       # Position covariance matrix value p_ED [m^2]
+float32 pos_cov_dd       # Position covariance matrix value p_DD [m^2]
 
 
-float32 vel_cov_nn       # Velocity covariance matrix value v_NN
-float32 vel_cov_ne       # Velocity covariance matrix value v_NE
-float32 vel_cov_nd       # Velocity covariance matrix value v_ND
-float32 vel_cov_ee       # Velocity covariance matrix value v_EE
-float32 vel_cov_ed       # Velocity covariance matrix value v_ED
-float32 vel_cov_dd       # Velocity covariance matrix value v_DD
+float32 vel_cov_nn       # Velocity covariance matrix value v_NN [m^2/s^2]
+float32 vel_cov_ne       # Velocity covariance matrix value v_NE [m^2/s^2]
+float32 vel_cov_nd       # Velocity covariance matrix value v_ND [m^2/s^2]
+float32 vel_cov_ee       # Velocity covariance matrix value v_EE [m^2/s^2]
+float32 vel_cov_ed       # Velocity covariance matrix value v_ED [m^2/s^2]
+float32 vel_cov_dd       # Velocity covariance matrix value v_DD [m^2/s^2]

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -38,6 +38,8 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::ATT,
                       ublox_msgs, NavATT)
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::CLOCK,
                       ublox_msgs, NavCLOCK)
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::COV,
+                      ublox_msgs, NavCOV)                      
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::DGPS,
                       ublox_msgs, NavDGPS)
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::DOP,


### PR DESCRIPTION
I would like to expose the UBX-NAV-COV message in order to get position and velocity covariance. I am using Humble and a ZED-F9P.