### PR TITLE
Added ability to inject additional extensions to monVer from param file.

### DIFF
--- a/ublox_gps/config/m8p_timing.yaml
+++ b/ublox_gps/config/m8p_timing.yaml
@@ -1,0 +1,15 @@
+# Configuration Settings for C94-M8P as a timing device
+
+debug: 1                    # Range 0-4 (0 means no debug statements will print)
+
+device: /dev/serial/by-id/usb-u-blox_AG_-_www.u-blox.com_u-blox_GNSS_receiver-if00
+frame_id: gps
+extensions: ["FWVER=TIM"]
+
+inf: 
+  all: true                   # Whether to display all INF messages in console
+
+publish:
+  all: false
+  tim:
+    tm2: true

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -33,6 +33,7 @@
 // STL
 #include <vector>
 #include <set>
+#include <ctime>
 // Boost
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -878,6 +879,27 @@ class UbloxFirmware7Plus : public UbloxFirmware {
     last_nav_pvt_ = m;
     freq_diag->diagnostic->tick(fix.header.stamp);
     updater->update();
+
+    static ros::Publisher time_ref_pub =
+        nh->advertise<sensor_msgs::TimeReference>("time_gps", kROSQueueSize);
+    sensor_msgs::TimeReference time_ref;
+    time_ref.header.stamp = fix.header.stamp;
+    time_ref.header.frame_id = frame_id;
+    time_ref.time_ref = fix.header.stamp;
+
+    struct tm sample_date = {
+      .tm_sec=m.sec,
+      .tm_min=m.min,
+      .tm_hour=m.hour,
+      .tm_mday=m.day,
+      .tm_mon=m.month - 1,
+      .tm_year=m.year - 1900,
+    };
+
+    time_t sample_time  = mktime(&sample_date);
+    uint sample_time_ms =  m.iTOW%1000;
+    time_ref.time_ref = ros::Time(sample_time, sample_time_ms*1e6);
+    time_ref_pub.publish(time_ref);
   }
 
  protected:

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -896,7 +896,7 @@ class UbloxFirmware7Plus : public UbloxFirmware {
       .tm_year=m.year - 1900,
     };
 
-    time_t sample_time  = mktime(&sample_date);
+    time_t sample_time  = mktime(&sample_date) - timezone;
     uint sample_time_ms =  m.iTOW%1000;
     time_ref.time_ref = ros::Time(sample_time, sample_time_ms*1e6);
     time_ref_pub.publish(time_ref);

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -373,6 +373,11 @@ void UbloxNode::processMonVer() {
                monVer.hwVersion.c_array());
   // Convert extension to vector of strings
   std::vector<std::string> extension;
+  // Inject any extensions from the parameter server
+  nh->getParam("extensions", extension);
+  for(std::size_t i = 0; i < extension.size(); ++i) {
+    ROS_DEBUG("Injected extension %s", extension[i].c_str());
+  }
   extension.reserve(monVer.extension.size());
   for(std::size_t i = 0; i < monVer.extension.size(); ++i) {
     ROS_DEBUG("%s", monVer.extension[i].field.c_array());


### PR DESCRIPTION
This is useful for operatating a REF/ROV as a TIM type device which the M8P is capable of doing.

To test run: `roslaunch ublox_gps ublox_device.launch param_file_name:=m8p_timing`
`/ublox/timtm2` topic will be published if a jumper is made between **TIMEPULSE** and **EXTINT**.
