### PR TITLE
Add support for protection level messages (#247)

### DIFF
--- a/ublox_gps/include/ublox_gps/ublox_firmware9.hpp
+++ b/ublox_gps/include/ublox_gps/ublox_firmware9.hpp
@@ -11,6 +11,7 @@
 #include <ublox_msgs/msg/cfg_valset_cfgdata.hpp>
 #include <ublox_msgs/msg/nav_timegps.hpp>
 #include <ublox_msgs/msg/nav_timeutc.hpp>
+#include <ublox_msgs/msg/nav_pl.hpp>
 
 #include <ublox_gps/fix_diagnostic.hpp>
 #include <ublox_gps/gnss.hpp>
@@ -45,11 +46,12 @@ private:
   /**
     * @brief Populate the CfgVALSETCfgData data type
     *
-    * @details A helper function used to generate a configuration for a single signal. 
+    * @details A helper function used to generate a configuration for a single signal.
     */
   ublox_msgs::msg::CfgVALSETCfgdata generateSignalConfig(uint32_t signalID, bool enable);
   rclcpp::Publisher<ublox_msgs::msg::NavTIMEGPS>::SharedPtr nav_timegps_pub_;
   rclcpp::Publisher<ublox_msgs::msg::NavTIMEUTC>::SharedPtr nav_timeutc_pub_;
+  rclcpp::Publisher<ublox_msgs::msg::NavPL>::SharedPtr nav_pl_pub_;
 };
 
 }  // namespace ublox_node

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -427,6 +427,8 @@ void UbloxNode::getRosParams() {
   this->declare_parameter("publish.nav.timegps", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.timeutc", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.velned", getRosBoolean(this, "publish.nav.all"));
+  this->declare_parameter("publish.nav.pl", getRosBoolean(this, "publish.nav.all"));
+
 
   this->declare_parameter("publish.rxm.all", getRosBoolean(this, "publish.all"));
   this->declare_parameter("publish.rxm.almRaw", getRosBoolean(this, "publish.rxm.all"));

--- a/ublox_gps/src/ublox_firmware9.cpp
+++ b/ublox_gps/src/ublox_firmware9.cpp
@@ -23,6 +23,10 @@ UbloxFirmware9::UbloxFirmware9(const std::string & frame_id, std::shared_ptr<dia
   {
     nav_timeutc_pub_ = node->create_publisher<ublox_msgs::msg::NavTIMEUTC>("navtimeutc", 1);
   }
+  if (getRosBoolean(node_, "publish.nav.pl"))
+  {
+    nav_pl_pub_ = node_->create_publisher<ublox_msgs::msg::NavPL>("navpl", 1);
+  }
 }
 
 bool UbloxFirmware9::configureUblox(std::shared_ptr<ublox_gps::Gps> gps)
@@ -127,7 +131,7 @@ ublox_msgs::msg::CfgVALSETCfgdata UbloxFirmware9::generateSignalConfig(uint32_t 
 }
 
 void UbloxFirmware9::subscribe(std::shared_ptr<ublox_gps::Gps> gps)
-{ 
+{
   UbloxFirmware8::subscribe(gps);
 
   // Subscribe to NAV TIMEGPS messages
@@ -140,6 +144,12 @@ void UbloxFirmware9::subscribe(std::shared_ptr<ublox_gps::Gps> gps)
   if (getRosBoolean(node_, "publish.nav.timeutc")) {
     gps->subscribe<ublox_msgs::msg::NavTIMEUTC>([this](const ublox_msgs::msg::NavTIMEUTC &m) {
       nav_timeutc_pub_->publish(m); }, 1);
+  }
+
+  // Subscribe to Nav PL
+  if (getRosBoolean(node_, "publish.nav.pl")) {
+    gps->subscribe<ublox_msgs::msg::NavPL>([this](const ublox_msgs::msg::NavPL &m) {
+      nav_pl_pub_->publish(m); }, 1);
   }
 }
 

--- a/ublox_msgs/CMakeLists.txt
+++ b/ublox_msgs/CMakeLists.txt
@@ -85,6 +85,7 @@ set(msg_files
   "msg/NavTIMEUTC.msg"
   "msg/NavVELECEF.msg"
   "msg/NavVELNED.msg"
+  "msg/NavPL.msg"
   "msg/RxmALM.msg"
   "msg/RxmEPH.msg"
   "msg/RxmRAW.msg"

--- a/ublox_msgs/include/ublox_msgs/serialization.hpp
+++ b/ublox_msgs/include/ublox_msgs/serialization.hpp
@@ -2501,6 +2501,68 @@ struct UbloxSerializer<ublox_msgs::msg::NavVELNED_<ContainerAllocator> > {
 };
 
 template <typename ContainerAllocator>
+struct UbloxSerializer<ublox_msgs::msg::NavPL_<ContainerAllocator>>
+{
+  inline static void read(const uint8_t *data, uint32_t count,
+                          ublox_msgs::msg::NavPL_<ContainerAllocator> &m)
+  {
+    UbloxIStream stream(const_cast<uint8_t *>(data), count);
+    stream.next(m.msg_version);
+    stream.next(m.tmir);
+    stream.next(m.tmir_exp);
+    stream.next(m.pl_pos_valid);
+    stream.next(m.pl_pos_frame);
+    stream.next(m.pl_vel_valid);
+    stream.next(m.pl_vel_frame);
+    stream.next(m.pl_time_valid);
+    stream.next(m.reserved0);
+    stream.next(m.i_tow);
+    stream.next(m.pl_pos1);
+    stream.next(m.pl_pos2);
+    stream.next(m.pl_pos3);
+    stream.next(m.pl_vel1);
+    stream.next(m.pl_vel2);
+    stream.next(m.pl_vel3);
+    stream.next(m.pl_pos_horiz_orientation);
+    stream.next(m.pl_vel_horiz_orientation);
+    stream.next(m.pl_time);
+    stream.next(m.reserved1);
+  }
+
+  inline static uint32_t serializedLength(const ublox_msgs::msg::NavPL_<ContainerAllocator> &m)
+  {
+    (void)m;
+    return 52;
+  }
+
+  inline static void write(uint8_t *data, uint32_t size,
+                           const ublox_msgs::msg::NavPL_<ContainerAllocator> &m)
+  {
+    UbloxOStream stream(data, size);
+    stream.next(m.msg_version);
+    stream.next(m.tmir);
+    stream.next(m.tmir_exp);
+    stream.next(m.pl_pos_valid);
+    stream.next(m.pl_pos_frame);
+    stream.next(m.pl_vel_valid);
+    stream.next(m.pl_vel_frame);
+    stream.next(m.pl_time_valid);
+    stream.next(m.reserved0);
+    stream.next(m.i_tow);
+    stream.next(m.pl_pos1);
+    stream.next(m.pl_pos2);
+    stream.next(m.pl_pos3);
+    stream.next(m.pl_vel1);
+    stream.next(m.pl_vel2);
+    stream.next(m.pl_vel3);
+    stream.next(m.pl_pos_horiz_orientation);
+    stream.next(m.pl_vel_horiz_orientation);
+    stream.next(m.pl_time);
+    stream.next(m.reserved1);
+  }
+};
+
+template <typename ContainerAllocator>
 struct UbloxSerializer<ublox_msgs::msg::NavTIMEGPS_<ContainerAllocator> > {
   inline static void read(const uint8_t *data, uint32_t count,
                           ublox_msgs::msg::NavTIMEGPS_<ContainerAllocator> & m) {
@@ -2567,7 +2629,7 @@ struct UbloxSerializer<ublox_msgs::msg::NavTIMEUTC_<ContainerAllocator> > {
     stream.next(m.valid);
   }
 };
-  
+
 ///
 /// @brief Serializes the RxmALM message which has a repeated block.
 ///

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
@@ -50,6 +50,7 @@
 #include <ublox_msgs/msg/nav_timeutc.hpp>
 #include <ublox_msgs/msg/nav_velecef.hpp>
 #include <ublox_msgs/msg/nav_velned.hpp>
+#include <ublox_msgs/msg/nav_pl.hpp>
 
 #include <ublox_msgs/msg/rxm_alm.hpp>
 #include <ublox_msgs/msg/rxm_eph.hpp>
@@ -177,6 +178,7 @@ namespace Message {
     static const uint8_t TIMEUTC = ublox_msgs::msg::NavTIMEUTC::MESSAGE_ID;
     static const uint8_t VELECEF = ublox_msgs::msg::NavVELECEF::MESSAGE_ID;
     static const uint8_t VELNED = ublox_msgs::msg::NavVELNED::MESSAGE_ID;
+    static const uint8_t PL = ublox_msgs::msg::NavPL::MESSAGE_ID;
   }  // namespace NAV
 
   namespace RXM {

--- a/ublox_msgs/msg/NavPL.msg
+++ b/ublox_msgs/msg/NavPL.msg
@@ -1,0 +1,33 @@
+# NAV_PL (0x01 0x62)
+# Navigation protection level
+
+uint8 CLASS_ID = 1
+uint8 MESSAGE_ID = 0x62
+
+uint8 msg_version
+uint8 tmir # Target misleading information risk [%MI/epoch]
+int8 tmir_exp
+
+uint8 pl_pos_valid
+uint8 pl_pos_frame
+uint8 pl_vel_valid
+uint8 pl_vel_frame
+uint8 pl_time_valid
+
+uint32 reserved0
+
+uint32 i_tow # GPS Millisecond time of week [ms]
+
+uint32 pl_pos1 # [mm]
+uint32 pl_pos2 # [mm]
+uint32 pl_pos3 # [mm]
+
+uint32 pl_vel1 # [mm/s]
+uint32 pl_vel2 # [mm/s]
+uint32 pl_vel3 # [mm/s]
+
+uint16 pl_pos_horiz_orientation # [deg - clockwise from true North]
+uint16 pl_vel_horiz_orientation # [deg - clockwise from true North]
+
+uint32 pl_time # [ns]
+uint32 reserved1

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -80,6 +80,8 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::VELECEF,
                       ublox_msgs, NavVELECEF)
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::VELNED,
                       ublox_msgs, NavVELNED)
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::NAV, ublox_msgs::Message::NAV::PL,
+                      ublox_msgs, NavPL)
 
 // ACK messages are declared differently because they both have the same
 // protocol, so only 1 ROS message is used


### PR DESCRIPTION
Adding protection level for the Ublox firmware version 9. The protection level is available for version greater than HPG-1.30.

The interface definition for the protection level was found here: https://content.u-blox.com/sites/default/files/documents/u-blox-F9-HPG-1.32_InterfaceDescription_UBX-22008968.pdf

I've tested this feature, and it works as expected. However, I'm not entirely sure it aligns with all community guidelines or if it could impact other integrations. Please review carefully for potential issues.