### PR TITLE
Add UBX-MON-SYS message to Firmware Gen. 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ To publish a given u-blox message to a ROS topic, set the parameter shown below 
 ### MON messages
 * `publish/mon/all`: This is the default value for the `publish/mon/<message>` parameters below. It defaults to `publish/all`. Individual messages can be enabled or disabled by setting the parameters below.
 * `publish/mon/hw`: Topic `~monhw`
+* `publish/mon/sys`: Topic `~monsys`
 
 ### NAV messages
 * `publish/nav/all`: This is the default value for the `publish/mon/<message>` parameters below. It defaults to `publish/all`. Individual messages can be enabled or disabled by setting the parameters below.

--- a/ublox_gps/include/ublox_gps/ublox_firmware9.hpp
+++ b/ublox_gps/include/ublox_gps/ublox_firmware9.hpp
@@ -9,6 +9,7 @@
 
 #include <ublox_msgs/msg/cfg_valset.hpp>
 #include <ublox_msgs/msg/cfg_valset_cfgdata.hpp>
+#include <ublox_msgs/msg/mon_sys.hpp>
 
 #include <ublox_gps/fix_diagnostic.hpp>
 #include <ublox_gps/gnss.hpp>
@@ -34,6 +35,11 @@ public:
     */
   bool configureUblox(std::shared_ptr<ublox_gps::Gps> gps) override;
 
+  /**
+   * @brief Subscribe to MonSYS messages.
+   */
+  void subscribe(std::shared_ptr<ublox_gps::Gps> gps) override;
+
 private:
   /**
     * @brief Populate the CfgVALSETCfgData data type
@@ -41,6 +47,7 @@ private:
     * @details A helper function used to generate a configuration for a single signal. 
     */
   ublox_msgs::msg::CfgVALSETCfgdata generateSignalConfig(uint32_t signalID, bool enable);
+  rclcpp::Publisher<ublox_msgs::msg::MonSYS>::SharedPtr mon_sys_pub_;
 };
 
 }  // namespace ublox_node

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -440,6 +440,7 @@ void UbloxNode::getRosParams() {
 
   this->declare_parameter("publish.mon.all", getRosBoolean(this, "publish.all"));
   this->declare_parameter("publish.mon.hw", getRosBoolean(this, "publish.mon.all"));
+  this->declare_parameter("publish.mon.sys", getRosBoolean(this, "publish.mon.all"));
 
   this->declare_parameter("publish.tim.tm2", false);
 

--- a/ublox_msgs/CMakeLists.txt
+++ b/ublox_msgs/CMakeLists.txt
@@ -58,6 +58,7 @@ set(msg_files
   "msg/MonGNSS.msg"
   "msg/MonHW6.msg"
   "msg/MonHW.msg"
+  "msg/MonSYS.msg"
   "msg/MonVERExtension.msg"
   "msg/MonVER.msg"
   "msg/NavATT.msg"

--- a/ublox_msgs/include/ublox_msgs/serialization.hpp
+++ b/ublox_msgs/include/ublox_msgs/serialization.hpp
@@ -1501,6 +1501,60 @@ struct UbloxSerializer<ublox_msgs::msg::MonHW6_<ContainerAllocator> > {
 };
 
 template <typename ContainerAllocator>
+struct UbloxSerializer<ublox_msgs::msg::MonSYS_<ContainerAllocator> > {
+  inline static void read(const uint8_t *data, uint32_t count,
+                          ublox_msgs::msg::MonSYS_<ContainerAllocator> & m) {
+    UbloxIStream stream(const_cast<uint8_t *>(data), count);
+    stream.next(m.version);
+    stream.next(m.boot_type);
+    stream.next(m.cpu_load);
+    stream.next(m.cpu_load_max);
+    stream.next(m.mem_usage);
+    stream.next(m.mem_usage_max);
+    stream.next(m.io_usage);
+    stream.next(m.io_usage_max);
+    stream.next(m.run_time);
+    stream.next(m.notice_count);
+    stream.next(m.warning_count);
+    stream.next(m.error_count);
+    stream.next(m.temperature);
+    stream.next(m.reserved0[0]);
+    stream.next(m.reserved0[1]);
+    stream.next(m.reserved0[2]);
+    stream.next(m.reserved0[3]);
+    stream.next(m.reserved0[4]);
+  }
+
+  inline static uint32_t serializedLength(const ublox_msgs::msg::MonSYS_<ContainerAllocator> & m) {
+    (void)m;
+    return 24;
+  }
+
+  inline static void write(uint8_t *data, uint32_t size,
+                           const ublox_msgs::msg::MonSYS_<ContainerAllocator> & m) {
+    UbloxOStream stream(data, size);
+    stream.next(m.version);
+    stream.next(m.boot_type);
+    stream.next(m.cpu_load);
+    stream.next(m.cpu_load_max);
+    stream.next(m.mem_usage);
+    stream.next(m.mem_usage_max);
+    stream.next(m.io_usage);
+    stream.next(m.io_usage_max);
+    stream.next(m.run_time);
+    stream.next(m.notice_count);
+    stream.next(m.warning_count);
+    stream.next(m.error_count);
+    stream.next(m.temperature);
+    stream.next(m.reserved0[0]);
+    stream.next(m.reserved0[1]);
+    stream.next(m.reserved0[2]);
+    stream.next(m.reserved0[3]);
+    stream.next(m.reserved0[4]);
+  }
+};
+
+template <typename ContainerAllocator>
 struct UbloxSerializer<ublox_msgs::msg::MonVERExtension_<ContainerAllocator> > {
   inline static void read(UbloxIStream& stream, ublox_msgs::msg::MonVERExtension_<ContainerAllocator> & m) {
     stream.next(m.field);

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
@@ -96,6 +96,7 @@
 #include <ublox_msgs/msg/mon_gnss.hpp>
 #include <ublox_msgs/msg/mon_hw.hpp>
 #include <ublox_msgs/msg/mon_hw6.hpp>
+#include <ublox_msgs/msg/mon_sys.hpp>
 #include <ublox_msgs/msg/mon_ver.hpp>
 
 #include <ublox_msgs/msg/aid_alm.hpp>
@@ -240,6 +241,7 @@ namespace Message {
   namespace MON {
     static const uint8_t GNSS = ublox_msgs::msg::MonGNSS::MESSAGE_ID;
     static const uint8_t HW = ublox_msgs::msg::MonHW::MESSAGE_ID;
+    static const uint8_t SYS = ublox_msgs::msg::MonSYS::MESSAGE_ID;
     static const uint8_t VER = ublox_msgs::msg::MonVER::MESSAGE_ID;
   }  // namespace MON
 

--- a/ublox_msgs/msg/MonSYS.msg
+++ b/ublox_msgs/msg/MonSYS.msg
@@ -1,0 +1,37 @@
+# MON-SYS (0x0A 0x39)
+# System Performance Information
+#
+# This message contains operationally relevant system information for 
+# monitoring purposes.
+
+
+uint8 CLASS_ID = 10           # 0x0A
+uint8 MESSAGE_ID = 57         # 0x39
+
+uint8 version                 # Message Version (0x01 for this version)
+uint8 boot_type               # Boot type of master chip
+uint8 BOOT_TYPE_UNKOWN = 0
+uint8 BOOT_TYPE_COLD_START = 1
+uint8 BOOT_TYPE_WATCHDOG = 2
+uint8 BOOT_TYPE_HW_RESET = 3
+uint8 BOOT_TYPE_HW_BACKUP = 4
+uint8 BOOT_TYPE_SW_BACKUP = 5
+uint8 BOOT_TYPE_SW_RESET = 6
+uint8 BOOT_TYPE_VIO_FAIL = 7
+uint8 BOOT_TYPE_VDD_X_FAIL = 8
+uint8 BOOT_TYPE_VDD_RF_FAIL = 9
+uint8 BOOT_TYPE_V_CORE_HIGH_FAIL = 10
+
+uint8 cpu_load                # CPU Load [%]
+uint8 cpu_load_max            # Maximum CPU Load [%] since last restart
+uint8 mem_usage               # Memory Usage [%]
+uint8 mem_usage_max           # Maximum Memory Usage [%] since last restart
+uint8 io_usage                # I/O Usage [%]
+uint8 io_usage_max            # Maximum I/O Usage [%] since last restart
+uint32 run_time               # Uptime [s] since last restart
+uint16 notice_count           # Number of notices since last restart
+uint16 warning_count          # Number of warnings since last restart
+uint16 error_count            # Number of errors since last restart
+int16 temperature             # Temperature [°C]
+
+uint8[5] reserved0            # Reserved for future use

--- a/ublox_msgs/src/ublox_msgs.cpp
+++ b/ublox_msgs/src/ublox_msgs.cpp
@@ -179,6 +179,8 @@ DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::HW,
                       ublox_msgs, MonHW)
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::HW,
                       ublox_msgs, MonHW6)
+DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::SYS,
+                      ublox_msgs, MonSYS)
 DECLARE_UBLOX_MESSAGE(ublox_msgs::Class::MON, ublox_msgs::Message::MON::VER,
                       ublox_msgs, MonVER)
 


### PR DESCRIPTION
UBX-MON-SYS (0x0A 0x39) message provides system performance information for monitoring purposes. It includes,
- CPU Load 
- Memory Usage 
- IO Usage
- Uptime
- Warning/Error Counts
- Temperature

Interface definition can be found [here](https://cdn.sparkfun.com/assets/9/4/0/2/8/u-blox-F9-HPS-1.30_InterfaceDescription_UBX-22010984.pdf)

This msg is useful in various testing and monitoring usecases.

I've tested it on ZED-F9P module and it works as expected.
