### PR TITLE
Add NAV-TIMEGPS and NAV-TIMEUTC implementation to Firmvare Ver. 9  resolves #239

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ To publish a given u-blox message to a ROS topic, set the parameter shown below 
 * `publish/nav/status`: Topic `~navstatus`
 * `publish/nav/svin`: Topic `~navsvin`. **HPG Reference Station Devices only**
 * `publish/nav/svinfo`: Topic `~navsvinfo`
+* `publish/nav/timegps`: Topic `~navtimegps`
+* `publish/nav/timeutc`: Topic `~navtimeutc`
 * `publish/nav/velned`: Topic `~navvelned`. **Firmware <= 6 only.** For firmware 7 and above, see NavPVT
 
 ### ESF messages

--- a/ublox_gps/include/ublox_gps/ublox_firmware9.hpp
+++ b/ublox_gps/include/ublox_gps/ublox_firmware9.hpp
@@ -9,6 +9,8 @@
 
 #include <ublox_msgs/msg/cfg_valset.hpp>
 #include <ublox_msgs/msg/cfg_valset_cfgdata.hpp>
+#include <ublox_msgs/msg/nav_timegps.hpp>
+#include <ublox_msgs/msg/nav_timeutc.hpp>
 
 #include <ublox_gps/fix_diagnostic.hpp>
 #include <ublox_gps/gnss.hpp>
@@ -34,6 +36,11 @@ public:
     */
   bool configureUblox(std::shared_ptr<ublox_gps::Gps> gps) override;
 
+  /**
+   * @brief Subscribe to NAV-TIMEUTC, NAV-TIMEGPS messages.
+   */
+  void subscribe(std::shared_ptr<ublox_gps::Gps> gps) override;
+
 private:
   /**
     * @brief Populate the CfgVALSETCfgData data type
@@ -41,6 +48,8 @@ private:
     * @details A helper function used to generate a configuration for a single signal. 
     */
   ublox_msgs::msg::CfgVALSETCfgdata generateSignalConfig(uint32_t signalID, bool enable);
+  rclcpp::Publisher<ublox_msgs::msg::NavTIMEGPS>::SharedPtr nav_timegps_pub_;
+  rclcpp::Publisher<ublox_msgs::msg::NavTIMEUTC>::SharedPtr nav_timeutc_pub_;
 };
 
 }  // namespace ublox_node

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -424,6 +424,8 @@ void UbloxNode::getRosParams() {
   this->declare_parameter("publish.nav.svin", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.svinfo", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.status", getRosBoolean(this, "publish.nav.all"));
+  this->declare_parameter("publish.nav.timegps", getRosBoolean(this, "publish.nav.all"));
+  this->declare_parameter("publish.nav.timeutc", getRosBoolean(this, "publish.nav.all"));
   this->declare_parameter("publish.nav.velned", getRosBoolean(this, "publish.nav.all"));
 
   this->declare_parameter("publish.rxm.all", getRosBoolean(this, "publish.all"));

--- a/ublox_msgs/include/ublox_msgs/serialization.hpp
+++ b/ublox_msgs/include/ublox_msgs/serialization.hpp
@@ -2529,6 +2529,44 @@ struct UbloxSerializer<ublox_msgs::msg::NavTIMEGPS_<ContainerAllocator> > {
     stream.next(m.t_acc);
   }
 };
+
+template <typename ContainerAllocator>
+struct UbloxSerializer<ublox_msgs::msg::NavTIMEUTC_<ContainerAllocator> > {
+  inline static void read(const uint8_t *data, uint32_t count,
+                          ublox_msgs::msg::NavTIMEUTC_<ContainerAllocator> & m) {
+    UbloxIStream stream(const_cast<uint8_t *>(data), count);
+    stream.next(m.i_tow);
+    stream.next(m.t_acc);
+    stream.next(m.nano);
+    stream.next(m.year);
+    stream.next(m.month);
+    stream.next(m.day);
+    stream.next(m.hour);
+    stream.next(m.min);
+    stream.next(m.sec);
+    stream.next(m.valid);
+  }
+
+  inline static uint32_t serializedLength(const ublox_msgs::msg::NavTIMEUTC_<ContainerAllocator> & m) {
+    (void)m;
+    return 20;
+  }
+
+  inline static void write(uint8_t *data, uint32_t size,
+                           const ublox_msgs::msg::NavTIMEUTC_<ContainerAllocator> & m) {
+    UbloxOStream stream(data, size);
+    stream.next(m.i_tow);
+    stream.next(m.t_acc);
+    stream.next(m.nano);
+    stream.next(m.year);
+    stream.next(m.month);
+    stream.next(m.day);
+    stream.next(m.hour);
+    stream.next(m.min);
+    stream.next(m.sec);
+    stream.next(m.valid);
+  }
+};
   
 ///
 /// @brief Serializes the RxmALM message which has a repeated block.


### PR DESCRIPTION
Completes the implementation of the NAV-TIMEGPS and NAV-TIMEUTC msgs.

It resolves the feature request mentioned  in #239 

Interface definition can be found [here](https://cdn.sparkfun.com/assets/9/4/0/2/8/u-blox-F9-HPS-1.30_InterfaceDescription_UBX-22010984.pdf)

I've tested it on ZED-F9P module and it works as expected.