### PR TITLE
fixed CfgNAVX5 message generation for protocol version >= 18

### DIFF
--- a/ublox_gps/config/neo_m8u_rover.yaml
+++ b/ublox_gps/config/neo_m8u_rover.yaml
@@ -11,7 +11,7 @@ ublox_gps_node:
 
     device: /dev/ttyACM0
     frame_id: m8u
-    rate: 4                     # in Hz
+    rate: 4.0                     # in Hz
     nav_rate: 4                 # [# of measurement cycles], recommended 1 Hz, may
                                 # be either 5 Hz (Dual constellation) or
                                 # 8 Hz (GPS only)
@@ -19,7 +19,7 @@ ublox_gps_node:
                                 # Max Alt: 50km
                                 # Max Horizontal Velocity: 250 m/s,
                                 # Max Vertical Velocity: 100 m/s
-    fix_mode: 3
+    fix_mode: 3d
     enable_ppp: true
     dr_limit: 1
 

--- a/ublox_gps/include/ublox_gps/adr_udr_product.hpp
+++ b/ublox_gps/include/ublox_gps/adr_udr_product.hpp
@@ -28,7 +28,7 @@ namespace ublox_node {
  */
 class AdrUdrProduct final : public virtual ComponentInterface {
  public:
-  explicit AdrUdrProduct(uint16_t nav_rate, uint16_t meas_rate, const std::string & frame_id, std::shared_ptr<diagnostic_updater::Updater> updater, rclcpp::Node* node);
+  explicit AdrUdrProduct(float protocol_version, uint16_t nav_rate, uint16_t meas_rate, const std::string & frame_id, std::shared_ptr<diagnostic_updater::Updater> updater, rclcpp::Node* node);
 
   /**
    * @brief Get the ADR/UDR parameters.
@@ -64,6 +64,7 @@ class AdrUdrProduct final : public virtual ComponentInterface {
  private:
   //! Whether or not to enable dead reckoning
   bool use_adr_;
+  float protocol_version_;
 
   sensor_msgs::msg::Imu imu_;
   sensor_msgs::msg::TimeReference t_ref_;

--- a/ublox_gps/include/ublox_gps/gps.hpp
+++ b/ublox_gps/include/ublox_gps/gps.hpp
@@ -300,7 +300,7 @@ class Gps final {
    * @note This is part of the expert settings. It is recommended you check
    * the ublox manual first.
    */
-  bool setPpp(bool enable);
+  bool setPpp(bool enable, float protocol_version);
 
   /**
    * @brief Set the DGNSS mode (see CfgDGNSS message for details).
@@ -314,7 +314,7 @@ class Gps final {
    * @param enable If true, enable ADR.
    * @return true on ACK, false on other conditions.
    */
-  bool setUseAdr(bool enable);
+  bool setUseAdr(bool enable, float protocol_version);
 
   /**
    * @brief Configure the U-Blox to UTC time

--- a/ublox_gps/src/adr_udr_product.cpp
+++ b/ublox_gps/src/adr_udr_product.cpp
@@ -25,8 +25,8 @@ namespace ublox_node {
 //
 // u-blox ADR devices, partially implemented
 //
-AdrUdrProduct::AdrUdrProduct(uint16_t nav_rate, uint16_t meas_rate, const std::string & frame_id, std::shared_ptr<diagnostic_updater::Updater> updater, rclcpp::Node* node)
-  : use_adr_(false), nav_rate_(nav_rate), meas_rate_(meas_rate), frame_id_(frame_id), updater_(updater), node_(node)
+AdrUdrProduct::AdrUdrProduct(float protocol_version, uint16_t nav_rate, uint16_t meas_rate, const std::string & frame_id, std::shared_ptr<diagnostic_updater::Updater> updater, rclcpp::Node* node)
+  : protocol_version_(protocol_version) ,use_adr_(false), nav_rate_(nav_rate), meas_rate_(meas_rate), frame_id_(frame_id), updater_(updater), node_(node)
 {
   if (getRosBoolean(node_, "publish.esf.meas")) {
     imu_pub_ =
@@ -63,7 +63,7 @@ void AdrUdrProduct::getRosParams() {
 }
 
 bool AdrUdrProduct::configureUblox(std::shared_ptr<ublox_gps::Gps> gps) {
-  if (!gps->setUseAdr(use_adr_)) {
+  if (!gps->setUseAdr(use_adr_, protocol_version_)) {
     throw std::runtime_error(std::string("Failed to ")
                              + (use_adr_ ? "enable" : "disable") + "use_adr");
   }

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -555,11 +555,14 @@ bool Gps::setDeadReckonLimit(uint8_t limit) {
   return configure(msg);
 }
 
-bool Gps::setPpp(bool enable) {
+bool Gps::setPpp(bool enable, float protocol_version) {
   RCLCPP_DEBUG(logger_,"%s PPP", (enable ? "Enabling" : "Disabling"));
 
   ublox_msgs::msg::CfgNAVX5 msg;
   msg.use_ppp = enable;
+  if(protocol_version >= 18){
+    msg.version = 2;
+  }
   msg.mask1 = ublox_msgs::msg::CfgNAVX5::MASK1_PPP;
   return configure(msg);
 }
@@ -571,11 +574,14 @@ bool Gps::setDgnss(uint8_t mode) {
   return configure(cfg);
 }
 
-bool Gps::setUseAdr(bool enable) {
+bool Gps::setUseAdr(bool enable, float protocol_version) {
   RCLCPP_DEBUG(logger_, "%s ADR/UDR", (enable ? "Enabling" : "Disabling"));
 
   ublox_msgs::msg::CfgNAVX5 msg;
   msg.use_adr = enable;
+  if(protocol_version >= 18){
+    msg.version = 2;
+  }
   msg.mask2 = ublox_msgs::msg::CfgNAVX5::MASK2_ADR;
   return configure(msg);
 }

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -229,11 +229,11 @@ void UbloxNode::addProductInterface(const std::string & product_category,
     components_.push_back(std::make_shared<TimProduct>(frame_id_, updater_, this));
   } else if (product_category == "ADR" ||
              product_category == "UDR") {
-    components_.push_back(std::make_shared<AdrUdrProduct>(nav_rate_, meas_rate_, frame_id_, updater_, this));
+    components_.push_back(std::make_shared<AdrUdrProduct>(protocol_version_, nav_rate_, meas_rate_, frame_id_, updater_, this));
   } else if (product_category == "FTS") {
     components_.push_back(std::make_shared<FtsProduct>());
   } else if (product_category == "HPS") {
-    components_.push_back(std::make_shared<AdrUdrProduct>(nav_rate_, meas_rate_, frame_id_, updater_, this));
+    components_.push_back(std::make_shared<AdrUdrProduct>(protocol_version_, nav_rate_, meas_rate_, frame_id_, updater_, this));
     components_.push_back(std::make_shared<HpgRovProduct>(nav_rate_, updater_, this));
   } else {
     RCLCPP_WARN(this->get_logger(), "Product category %s %s from MonVER message not recognized %s",
@@ -772,7 +772,7 @@ bool UbloxNode::configureUblox() {
                                   " SBAS.");
         }
       }
-      if (!gps_->setPpp(getRosBoolean(this, "enable_ppp"))) {
+      if (!gps_->setPpp(getRosBoolean(this, "enable_ppp"), protocol_version_)) {
         throw std::runtime_error(std::string("Failed to ") +
                                 (getRosBoolean(this, "enable_ppp") ? "enable" : "disable")
                                 + " PPP.");


### PR DESCRIPTION
This PR addresses a protocol version issue similar to the one previously fixed in the master branch (see PR #89). While working on the ros2 branch with ROS2 Humble, I encountered the same issue. I referenced the resolution in PR #89 and applied similar changes to resolve it here in ros2 as well.

Given that others using the Neo M8U GPS module on the ros2 branch might face this issue, I have fixed and thoroughly tested it. The GPS module is running smoothly in our production environment, so merging this fix into ros2 would benefit future users. Thank you