### PR TITLE
Thrown a Runtime Error on config Fail

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -807,7 +807,7 @@ bool UbloxNode::configureUblox() {
     }
   } catch (const std::exception& e) {
     RCLCPP_FATAL(this->get_logger(), "Error configuring u-blox: %s", e.what());
-    return false;
+    throw std::runtime_error("Failed to configure u-blox receiver.");
   }
   return true;
 }


### PR DESCRIPTION
If the U-blox is not correctly configured, it is logged as FATAL, but the node does not crash/exit. This leads to a 'zombie node' running and prevents handling of this error outside the node itself. 

I added a runtime_error to this condition, so the node actually dies. This can then be handled via the 'restart=True' parameter in a ros2 launch file.