### PR TITLE
fix: raw_data_stream uses wrong is_ros_subscriber flag

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -383,8 +383,7 @@ void UbloxNode::getRosParams() {
   // raw data stream logging
   this->declare_parameter("raw_data_stream.enable", false);
   if (getRosBoolean(this, "raw_data_stream.enable")) {
-    raw_data_stream_pa_ = std::make_shared<ublox_node::RawDataStreamPa>(
-      getRosBoolean(this, "raw_data_stream.enable"));
+    raw_data_stream_pa_ = std::make_shared<ublox_node::RawDataStreamPa>(false);
     raw_data_stream_pa_->getRosParams();
   }
 


### PR DESCRIPTION
When raw_data_stream.enable is true, RawDataStreamPa is constructed with is_ros_subscriber=true, which puts it in subscriber mode. In subscriber mode:
- getRosParams() reads 'dir' instead of 'raw_data_stream.dir'
- isEnabled() only returns !file_dir_.empty(), ignoring 'publish' flag
- setRawDataCallback() is never called → no data flows

Fix: pass false as is_ros_subscriber since the GPS node is a producer, not a subscriber of the raw data stream.