### PR TITLE
io_service -> io_context

### DIFF
--- a/ublox_gps/include/ublox_gps/async_worker.hpp
+++ b/ublox_gps/include/ublox_gps/async_worker.hpp
@@ -39,7 +39,7 @@
 
 #include <asio/buffer.hpp>
 #include <asio/error_code.hpp>
-#include <asio/io_service.hpp>
+#include <asio/io_context.hpp>
 #include <asio/placeholders.hpp>
 #include <asio/write.hpp>
 #include <asio/ip/udp.hpp>
@@ -59,11 +59,11 @@ class AsyncWorker final : public Worker {
   /**
    * @brief Construct an Asynchronous I/O worker.
    * @param stream the stream for th I/O service
-   * @param io_service the I/O service
+   * @param io_context the I/O service
    * @param buffer_size the size of the input and output buffers
    */
   explicit AsyncWorker(std::shared_ptr<StreamT> stream,
-                       std::shared_ptr<asio::io_service> io_service,
+                       std::shared_ptr<asio::io_context> io_context,
                        std::size_t buffer_size,
                        int debug,
                        const rclcpp::Logger& logger);
@@ -124,7 +124,7 @@ class AsyncWorker final : public Worker {
   void doClose();
 
   std::shared_ptr<StreamT> stream_; //!< The I/O stream
-  std::shared_ptr<asio::io_service> io_service_; //!< The I/O service
+  std::shared_ptr<asio::io_context> io_context_; //!< The I/O service
 
   std::mutex read_mutex_; //!< Lock for the input buffer
   std::condition_variable read_condition_;
@@ -150,24 +150,24 @@ class AsyncWorker final : public Worker {
 
 template <typename StreamT>
 AsyncWorker<StreamT>::AsyncWorker(std::shared_ptr<StreamT> stream,
-        std::shared_ptr<asio::io_service> io_service,
+        std::shared_ptr<asio::io_context> io_context,
         std::size_t buffer_size,
         int debug,
         const rclcpp::Logger& logger)
-    : stream_(stream), io_service_(io_service), in_buffer_size_(0), stopping_(false), debug_(debug), logger_(logger) {
+    : stream_(stream), io_context_(io_context), in_buffer_size_(0), stopping_(false), debug_(debug), logger_(logger) {
   in_.resize(buffer_size);
 
   out_.reserve(buffer_size);
 
-  io_service_->post(std::bind(&AsyncWorker<StreamT>::doRead, this));
-  background_thread_ = std::make_shared<std::thread>([this]{ io_service_->run(); });
+  asio::post(io_context_->get_executor(), std::bind(&AsyncWorker<StreamT>::doRead, this));
+  background_thread_ = std::make_shared<std::thread>([this]{ io_context_->run(); });
 }
 
 template <typename StreamT>
 AsyncWorker<StreamT>::~AsyncWorker() {
-  io_service_->post(std::bind(&AsyncWorker<StreamT>::doClose, this));
+  asio::post(io_context_->get_executor(), std::bind(&AsyncWorker<StreamT>::doClose, this));
   background_thread_->join();
-  //io_service_->reset();
+  //io_context_->reset();
 }
 
 template <typename StreamT>
@@ -185,7 +185,7 @@ bool AsyncWorker<StreamT>::send(const unsigned char* data,
   }
   out_.insert(out_.end(), data, data + size);
 
-  io_service_->post(std::bind(&AsyncWorker<StreamT>::doWrite, this));
+  asio::post(io_context_->get_executor(), std::bind(&AsyncWorker<StreamT>::doWrite, this));
   return true;
 }
 
@@ -314,7 +314,7 @@ void AsyncWorker<StreamT>::readEnd(const asio::error_code& error,
   }
 
   if (!stopping_) {
-    io_service_->post(std::bind(&AsyncWorker<StreamT>::doRead, this));
+    asio::post(io_context_->get_executor(), std::bind(&AsyncWorker<StreamT>::doRead, this));
   }
 }
 

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -33,7 +33,8 @@
 #include <stdexcept>
 #include <thread>
 
-#include <asio/io_service.hpp>
+#include <asio/connect.hpp>
+#include <asio/io_context.hpp>
 #include <asio/serial_port.hpp>
 #include <asio/serial_port_base.hpp>
 #include <asio/ip/tcp.hpp>
@@ -129,8 +130,8 @@ void Gps::processUpdSosAck(const ublox_msgs::msg::UpdSOSAck &m) {
 void Gps::initializeSerial(const std::string & port, unsigned int baudrate,
                            uint16_t uart_in, uint16_t uart_out) {
   port_ = port;
-  auto io_service = std::make_shared<asio::io_service>();
-  auto serial = std::make_shared<asio::serial_port>(*io_service);
+  auto io_context = std::make_shared<asio::io_context>();
+  auto serial = std::make_shared<asio::serial_port>(*io_context);
 
   // open serial port
   try {
@@ -152,7 +153,7 @@ void Gps::initializeSerial(const std::string & port, unsigned int baudrate,
   if (worker_) {
     return;
   }
-  setWorker(std::make_shared<AsyncWorker<asio::serial_port>>(serial, io_service, 8192, debug_, logger_));
+  setWorker(std::make_shared<AsyncWorker<asio::serial_port>>(serial, io_context, 8192, debug_, logger_));
 
   configured_ = false;
 
@@ -185,8 +186,8 @@ void Gps::initializeSerial(const std::string & port, unsigned int baudrate,
 }
 
 void Gps::resetSerial(const std::string & port) {
-  auto io_service = std::make_shared<asio::io_service>();
-  auto serial = std::make_shared<asio::serial_port>(*io_service);
+  auto io_context = std::make_shared<asio::io_context>();
+  auto serial = std::make_shared<asio::serial_port>(*io_context);
 
   // open serial port
   try {
@@ -202,7 +203,7 @@ void Gps::resetSerial(const std::string & port) {
   if (worker_) {
     return;
   }
-  setWorker(std::make_shared<AsyncWorker<asio::serial_port>>(serial, io_service, 8192, debug_, logger_));
+  setWorker(std::make_shared<AsyncWorker<asio::serial_port>>(serial, io_context, 8192, debug_, logger_));
   configured_ = false;
 
   // Poll UART PRT Config
@@ -227,69 +228,69 @@ void Gps::resetSerial(const std::string & port) {
 void Gps::initializeTcp(const std::string & host, const std::string & port) {
   host_ = host;
   port_ = port;
-  auto io_service = std::make_shared<asio::io_service>();
-  asio::ip::tcp::resolver::iterator endpoint;
+  auto io_context = std::make_shared<asio::io_context>();
+  asio::ip::tcp::resolver::results_type endpoint;
 
   try {
-    asio::ip::tcp::resolver resolver(*io_service);
+    asio::ip::tcp::resolver resolver(*io_context);
     endpoint =
-        resolver.resolve(asio::ip::tcp::resolver::query(host, port));
+        resolver.resolve(host, port);
   } catch (const std::runtime_error& e) {
     throw std::runtime_error("U-Blox: Could not resolve" + host + " " +
                              port + " " + e.what());
   }
 
-  auto socket = std::make_shared<asio::ip::tcp::socket>(*io_service);
+  auto socket = std::make_shared<asio::ip::tcp::socket>(*io_context);
 
   try {
-    socket->connect(*endpoint);
+    asio::connect(*socket, endpoint);
   } catch (const std::runtime_error& e) {
     throw std::runtime_error("U-Blox: Could not connect to " +
-                             endpoint->host_name() + ":" +
-                             endpoint->service_name() + ": " + e.what());
+                             endpoint.begin()->host_name() + ":" +
+                             endpoint.begin()->service_name() + ": " + e.what());
   }
 
-  RCLCPP_INFO(logger_, "U-Blox: Connected to %s:%s.", endpoint->host_name().c_str(),
-              endpoint->service_name().c_str());
+  RCLCPP_INFO(logger_, "U-Blox: Connected to %s:%s.", endpoint.begin()->host_name().c_str(),
+              endpoint.begin()->service_name().c_str());
 
   if (worker_) {
     return;
   }
-  setWorker(std::make_shared<AsyncWorker<asio::ip::tcp::socket>>(socket, io_service, 8192, debug_, logger_));
+  setWorker(std::make_shared<AsyncWorker<asio::ip::tcp::socket>>(socket, io_context, 8192, debug_, logger_));
 }
 
 void Gps::initializeUdp(const std::string & host, const std::string & port) {
   host_ = host;
   port_ = port;
-  auto io_service = std::make_shared<asio::io_service>();
-  asio::ip::udp::resolver::iterator endpoint;
+  auto io_context = std::make_shared<asio::io_context>();
+  asio::ip::udp::resolver::results_type endpoint;
 
   try {
-    asio::ip::udp::resolver resolver(*io_service);
+    asio::ip::udp::resolver resolver(*io_context);
     endpoint =
-        resolver.resolve(asio::ip::udp::resolver::query(host, port));
+        resolver.resolve(host, port);
   } catch (const std::runtime_error& e) {
     throw std::runtime_error("U-Blox: Could not resolve" + host + " " +
                              port + " " + e.what());
   }
 
-  auto socket = std::make_shared<asio::ip::udp::socket>(*io_service);
+  auto socket = std::make_shared<asio::ip::udp::socket>(*io_context);
 
   try {
-    socket->connect(*endpoint);
+    asio::connect(*socket, endpoint);
   } catch (const std::runtime_error& e) {
     throw std::runtime_error("U-Blox: Could not connect to " +
-                             endpoint->host_name() + ":" +
-                             endpoint->service_name() + ": " + e.what());
+                             endpoint.begin()->host_name() + ":" +
+                             endpoint.begin()->service_name() + ": " + e.what());
   }
 
-  RCLCPP_INFO(logger_, "U-Blox: Connected to %s:%s.", endpoint->host_name().c_str(),
-              endpoint->service_name().c_str());
+  RCLCPP_INFO(logger_, "U-Blox: Connected to %s:%s.", endpoint.begin()->host_name().c_str(),
+              endpoint.begin()->service_name().c_str());
 
   if (worker_) {
     return;
   }
-  setWorker(std::make_shared<AsyncWorker<asio::ip::udp::socket>>(socket, io_service, 8192, debug_, logger_));
+  setWorker(std::make_shared<AsyncWorker<asio::ip::udp::socket>>(socket, io_context, 8192, debug_, logger_));
 }
 
 void Gps::close() {


### PR DESCRIPTION
Hi,

This fix build for asio 1.36.

`io_service` has been deprecated for at least 9 years (ref. blame https://github.com/boostorg/asio/blame/995eeab56906ab0a1f614602aa0dee9ee88bf8cb/include/boost/asio/io_service.hpp), and removed in https://github.com/boostorg/asio/commit/ec0908c562102915423d8bd7aefd3079efbb6c86