### PR TITLE
[fix] nmea callback: remove \0 bytes to avoid CDR crash

### DIFF
--- a/ublox_gps/include/ublox_gps/callback.hpp
+++ b/ublox_gps/include/ublox_gps/callback.hpp
@@ -29,6 +29,7 @@
 #ifndef UBLOX_GPS_CALLBACK_HPP
 #define UBLOX_GPS_CALLBACK_HPP
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -203,6 +204,9 @@ class CallbackHandlers final {
     size_t nmea_end = buffer.find('\n', nmea_start);
     while(nmea_start != std::string::npos && nmea_end != std::string::npos) {
       std::string sentence = buffer.substr(nmea_start, nmea_end - nmea_start + 1);
+      // Strip null characters that may be present in binary data misidentified
+      // as NMEA. FastCDR >= 2.2.7 throws BadParamException on strings with nulls.
+      sentence.erase(std::remove(sentence.begin(), sentence.end(), '\0'), sentence.end());
       callback_nmea_(sentence);
 
       nmea_start = buffer.find('$', nmea_end + 1);


### PR DESCRIPTION


In my setup (moving base 2x ublox F9P, ROS2 Jazzy) RTCM messages are published on the same UART channel as connection to my PC. This driver currently wrongly interprets this as NMEA. 
'\0' bytes in the RTCM messages will come in. and are processed by FastCDR to the ROS middleware. The new FastCDR 2.2.7, throws when serializing '\0' bytes to characters, making the driver crash.

```
terminate called after throwing an instance of 'eprosima::fastcdr::exception::BadParamException'
  what():  The string contains null characters
```

This fixes it, but proper handling of RTCM messages is adviced.
Valid NMEA is ASCII and never contains \0 byte, legitimate NMEA will not be deleted.

`publish.nmea: false` should also avoid the crash.

