### PR TITLE
Export Message keys storage on Windows

### DIFF
--- a/ublox_serialization/include/ublox_serialization/serialization.hpp
+++ b/ublox_serialization/include/ublox_serialization/serialization.hpp
@@ -325,7 +325,7 @@ class Message {
   };
 
  private:
-  static std::vector<std::pair<uint8_t,uint8_t> > keys_;
+  static UBLOX_SERIALIZATION_EXPORT std::vector<std::pair<uint8_t,uint8_t> > keys_;
 };
 
 /**


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-ublox-serialization.win.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: the static Message::keys_ storage is part of the ublox_serialization library ABI. Marking it with UBLOX_SERIALIZATION_EXPORT makes the symbol visible when building or consuming the library as a Windows DLL.