### PR TITLE
Fix ublox_msgs Windows portability

### DIFF
--- a/ublox_msgs/CMakeLists.txt
+++ b/ublox_msgs/CMakeLists.txt
@@ -10,6 +10,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if(WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(sensor_msgs REQUIRED)

--- a/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
+++ b/ublox_msgs/include/ublox_msgs/ublox_msgs.hpp
@@ -191,7 +191,16 @@ namespace Message {
   }  // namespace RXM
 
   namespace INF {
+#if defined(_WIN32) && defined(ERROR)
+#pragma push_macro("ERROR")
+#undef ERROR
+#define UBLOX_MSGS_RESTORE_ERROR_MACRO
+#endif
     static const uint8_t ERROR = 0x00;
+#if defined(UBLOX_MSGS_RESTORE_ERROR_MACRO)
+#pragma pop_macro("ERROR")
+#undef UBLOX_MSGS_RESTORE_ERROR_MACRO
+#endif
     static const uint8_t WARNING = 0x01;
     static const uint8_t NOTICE = 0x02;
     static const uint8_t TEST = 0x03;


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: `patch/ros-rolling-ublox-msgs.win.patch`, authored by Daisuke Nishimatsu.

This keeps the ROS 2 `ublox_msgs` headers and support library friendlier to Windows builds. The Windows SDK can define `ERROR` as a macro, which collides with the existing `ublox_msgs::Message::INF::ERROR` constant in the public header. The guard keeps the existing API while avoiding that macro collision.

The support library is also built with `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` on Windows so downstream consumers can link the generated DLL without hand-maintained export annotations.
