### PR TITLE
Improve ublox_gps Windows portability

### DIFF
--- a/ublox_gps/CMakeLists.txt
+++ b/ublox_gps/CMakeLists.txt
@@ -67,6 +67,9 @@ target_link_libraries(ublox_gps PUBLIC
   ${ublox_msgs_TARGETS}
   ublox_serialization::ublox_serialization
 )
+if(MSVC)
+  target_compile_definitions(ublox_gps PRIVATE _USE_MATH_DEFINES)
+endif()
 
 install(TARGETS ublox_gps EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/ublox_gps/include/ublox_gps/ublox_firmware7plus.hpp
+++ b/ublox_gps/include/ublox_gps/ublox_firmware7plus.hpp
@@ -17,6 +17,12 @@
 #include <ublox_gps/ublox_firmware.hpp>
 #include <ublox_gps/utils.hpp>
 
+#if defined(_WIN32) && defined(ERROR)
+#pragma push_macro("ERROR")
+#undef ERROR
+#define UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif
+
 namespace ublox_node {
 
 /**
@@ -210,5 +216,10 @@ class UbloxFirmware7Plus : public UbloxFirmware {
 };
 
 }  // namespace ublox_node
+
+#ifdef UBLOX_GPS_RESTORE_ERROR_MACRO
+#pragma pop_macro("ERROR")
+#undef UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif
 
 #endif  // UBLOX_GPS_UBLOX_FIRMWARE7PLUS_HPP

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -142,11 +142,13 @@ void Gps::initializeSerial(const std::string & port, unsigned int baudrate,
 
   RCLCPP_INFO(logger_, "U-Blox: Opened serial port %s", port.c_str());
 
+#ifndef _WIN32
   int fd = serial->native_handle();
   termios tio{};
   tcgetattr(fd, &tio);
   cfmakeraw(&tio);
   tcsetattr(fd, TCSANOW, &tio);
+#endif
 
   // Set the I/O worker
   if (worker_) {

--- a/ublox_gps/src/hpg_ref_product.cpp
+++ b/ublox_gps/src/hpg_ref_product.cpp
@@ -16,6 +16,12 @@
 #include <ublox_gps/rtcm.hpp>
 #include <ublox_gps/utils.hpp>
 
+#if defined(_WIN32) && defined(ERROR)
+#pragma push_macro("ERROR")
+#undef ERROR
+#define UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif
+
 namespace ublox_node {
 
 //
@@ -256,3 +262,8 @@ void HpgRefProduct::tmode3Diagnostics(
 }
 
 }  // namespace ublox_node
+
+#ifdef UBLOX_GPS_RESTORE_ERROR_MACRO
+#pragma pop_macro("ERROR")
+#undef UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif

--- a/ublox_gps/src/hpg_rov_product.cpp
+++ b/ublox_gps/src/hpg_rov_product.cpp
@@ -15,6 +15,12 @@
 #include <ublox_gps/ublox_topic_diagnostic.hpp>
 #include <ublox_gps/utils.hpp>
 
+#if defined(_WIN32) && defined(ERROR)
+#pragma push_macro("ERROR")
+#undef ERROR
+#define UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif
+
 namespace ublox_node {
 
 //
@@ -101,3 +107,8 @@ void HpgRovProduct::callbackNavRelPosNed(const ublox_msgs::msg::NavRELPOSNED &m)
 }
 
 }  // namespace ublox_node
+
+#ifdef UBLOX_GPS_RESTORE_ERROR_MACRO
+#pragma pop_macro("ERROR")
+#undef UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -73,6 +73,12 @@
 #include <ublox_gps/ublox_firmware8.hpp>
 #include <ublox_gps/ublox_firmware9.hpp>
 
+#if defined(_WIN32) && defined(ERROR)
+#pragma push_macro("ERROR")
+#undef ERROR
+#define UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif
+
 namespace ublox_node {
 
 /**
@@ -653,8 +659,8 @@ void UbloxNode::processMonVer() {
     RCLCPP_DEBUG(this->get_logger(), "%s",
                  std::string(monVer.extension[i].field.begin(), monVer.extension[i].field.end()).c_str());
     // Find the end of the string (null character)
-    unsigned char* end = std::find(monVer.extension[i].field.begin(),
-                                   monVer.extension[i].field.end(), '\0');
+    auto end = std::find(
+      monVer.extension[i].field.begin(), monVer.extension[i].field.end(), '\0');
     extensions.emplace_back(std::string(monVer.extension[i].field.begin(), end));
   }
 
@@ -939,5 +945,10 @@ UbloxNode::~UbloxNode() {
 }
 
 }  // namespace ublox_node
+
+#ifdef UBLOX_GPS_RESTORE_ERROR_MACRO
+#pragma pop_macro("ERROR")
+#undef UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif
 
 RCLCPP_COMPONENTS_REGISTER_NODE(ublox_node::UbloxNode)

--- a/ublox_gps/src/ublox_firmware6.cpp
+++ b/ublox_gps/src/ublox_firmware6.cpp
@@ -22,6 +22,12 @@
 #include <ublox_gps/ublox_firmware6.hpp>
 #include <ublox_gps/utils.hpp>
 
+#if defined(_WIN32) && defined(ERROR)
+#pragma push_macro("ERROR")
+#undef ERROR
+#define UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif
+
 namespace ublox_node {
 
 //
@@ -244,3 +250,8 @@ void UbloxFirmware6::callbackNavSol(const ublox_msgs::msg::NavSOL& m) {
 }
 
 }  // namespace ublox_node
+
+#ifdef UBLOX_GPS_RESTORE_ERROR_MACRO
+#pragma pop_macro("ERROR")
+#undef UBLOX_GPS_RESTORE_ERROR_MACRO
+#endif


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack patch/ros-rolling-ublox-gps.patch, authored by Daisuke Nishimatsu.

This carries the non-duplicated Windows portability pieces from the RoboStack patch: define _USE_MATH_DEFINES for MSVC, skip POSIX termios raw-mode calls on Windows, preserve and undefine the Windows ERROR macro while parsing ROS constants named ERROR, and use auto for the MonVER extension iterator.

I intentionally did not include the Asio io_service to io_context migration here because it is already covered by upstream PR #273.